### PR TITLE
edit: include file name in invalid file name error message and put filename validation into FileExtension GetFullFileNameForJson method

### DIFF
--- a/HideAndSeekClassLibrary/FileExtensions.cs
+++ b/HideAndSeekClassLibrary/FileExtensions.cs
@@ -26,8 +26,16 @@ namespace HideAndSeek
         /// <param name="fileSystem"></param>
         /// <param name="fileName">Name of file not including extension</param>
         /// <returns>Full name of file including extension</returns>
+        /// <exception cref="InvalidDataException">Exception thrown if file name is invalid</exception>
         public static string GetFullFileNameForJson(this IFileSystem fileSystem, string fileName)
         {
+            // If file name is invalid
+            if( !(fileSystem.IsValidName(fileName)) )
+            {
+                throw new InvalidDataException($"Cannot perform action because file name \"{fileName}\" is invalid (is empty or contains illegal characters, e.g. \\, /, or whitespace)");
+            }
+
+            // Return file name with extension
             return $"{fileName}{JsonFileExtension}";
         }
 

--- a/HideAndSeekClassLibrary/GameController.cs
+++ b/HideAndSeekClassLibrary/GameController.cs
@@ -264,7 +264,7 @@ namespace HideAndSeek
                     string fileName = input.Substring(indexOfSpace + 1);
 
                     // If file name is valid
-                    if (_fileSystem.IsValidName(fileName))
+                    if(_fileSystem.IsValidName(fileName))
                     {
                         // If input requests save game
                         if (lowercaseCommand == "save")
@@ -280,10 +280,15 @@ namespace HideAndSeek
                             return DeleteGame(fileName); // Delete game and return message
                         }
                     }
+                    else // If the file name is invalid
+                    {
+                        return $"Cannot perform action because file name \"{fileName}\" is invalid (is empty or contains illegal characters, e.g. \\, /, or whitespace)"; // Return failure message
+                    }
+                } 
+                else // If input does not include a space
+                {
+                    return "Cannot perform action because no file name was entered"; // Return failure message
                 }
-
-                // If any of the requirements for file name input are not met, return failure message
-                return "Cannot perform action because file name is invalid (is empty or contains illegal characters, e.g. \\, /, or whitespace)";
             }
             else if ( !(Enum.TryParse(originalCommand, out Direction direction)) ) // If input cannot be parsed to Direction enum value
             {

--- a/HideAndSeekTestProject/FileExtensionsTests.cs
+++ b/HideAndSeekTestProject/FileExtensionsTests.cs
@@ -23,10 +23,39 @@ namespace HideAndSeekTestProject
         }
 
         [Test]
-        [Category("FileExtensions GetFullFileNameForJson")]
-        public void Test_FileExtensions_GetFullFileNameForJson()
+        [Category("FileExtensions GetFullFileNameForJson Success")]
+        public void Test_FileExtensions_GetFullFileNameForJson_WithValidFileName()
         {
             Assert.That(fileSystem.GetFullFileNameForJson("myFile"), Is.EqualTo("myFile.json"));
+        }
+
+        [TestCase("")]
+        [TestCase(" ")]
+        [TestCase("my file")]
+        [TestCase(" myFile")]
+        [TestCase("myFile ")]
+        [TestCase("\\")]
+        [TestCase("\\myFile")]
+        [TestCase("myFile\\")]
+        [TestCase("my\\File")]
+        [TestCase("/")]
+        [TestCase("/myFile")]
+        [TestCase("myFile/")]
+        [TestCase("my/File")]
+        [Category("FileExtensions GetFullFileNameForJson Failure")]
+        public void Test_FileExtensions_GetFullFileNameForJson_WithInvalidFileName_ThrowsException(string fileName)
+        {
+            Assert.Multiple(() =>
+            {
+                // Assert that getting full file name with invalid file name raises an exception
+                var exception = Assert.Throws<InvalidDataException>(() =>
+                {
+                    fileSystem.GetFullFileNameForJson(fileName);
+                });
+
+                // Assert that exception message is as expected
+                Assert.That(exception.Message, Is.EqualTo($"Cannot perform action because file name \"{fileName}\" is invalid (is empty or contains illegal characters, e.g. \\, /, or whitespace)"));
+            });
         }
 
         [TestCase("myFile")]

--- a/HideAndSeekTestProject/GameControllerSaveGameTests.cs
+++ b/HideAndSeekTestProject/GameControllerSaveGameTests.cs
@@ -23,11 +23,22 @@ namespace HideAndSeek
         [Test, Category("GameController Save Load Delete Error")]
         public void Test_GameController_ParseInput_ToSaveLoadOrDeleteGame_AndCheckErrorMessage_WhenFileNameIsInvalid(
             [Values("save", "load", "delete")] string commandKeyword,
-            [Values("", " ", " my saved game", " my\\saved\\game", " my/saved/game", " my/saved\\ game")] string restOfCommand)
+            [Values(" ", " my saved game", " my\\saved\\game", " my/saved/game", " my/saved\\ game")] string restOfCommand)
         {
             gameController = new GameController();
             message = gameController.ParseInput(commandKeyword + restOfCommand);
-            Assert.That(message, Is.EqualTo("Cannot perform action because file name is invalid (is empty or contains illegal characters, e.g. \\, /, or whitespace)"));
+            Assert.That(message, Is.EqualTo($"Cannot perform action because file name \"{restOfCommand.Substring(1)}\" is invalid (is empty or contains illegal characters, e.g. \\, /, or whitespace)"));
+        }
+
+        [TestCase("save")]
+        [TestCase("load")]
+        [TestCase("delete")]
+        [Category("GameController Save Load Delete Error")]
+        public void Test_GameController_ParseInput_ToSaveLoadOrDeleteGame_AndCheckErrorMessage_WhenNoFileNameEntered(string commandWord)
+        {
+            gameController = new GameController();
+            message = gameController.ParseInput(commandWord);
+            Assert.That(message, Is.EqualTo("Cannot perform action because no file name was entered"));
         }
 
         [Test, Category("GameController Save Error")]

--- a/HideAndSeekTestProject/SavedGameTests.cs
+++ b/HideAndSeekTestProject/SavedGameTests.cs
@@ -23,7 +23,8 @@ namespace HideAndSeek
             validOpponentsAndHidingPlacesDictionary.Add("Bob", "Bathroom");
         }
 
-        [TestCase]
+        [Test]
+        [Category("SavedGame HouseFileName Success")]
         public void Test_SavedGame_SetHouseFileName_ToValidValue_AndGet()
         {
             // Create SavedGame object with valid House file name
@@ -41,8 +42,9 @@ namespace HideAndSeek
             Assert.That(savedGame.HouseFileName, Is.EqualTo("DefaultHouse"));
         }
 
-        [TestCase]
-        public void Test_SavedGame_SetHouseFileName_ToInvalidValue_NonexistentFile_AndGet()
+        [Test]
+        [Category("SavedGame HouseFileName Failure")]
+        public void Test_SavedGame_SetHouseFileName_ToInvalidValue_NonexistentFile()
         {
             Assert.Multiple(() =>
             {
@@ -61,6 +63,42 @@ namespace HideAndSeek
 
                 // Assert that exception message is as expected
                 Assert.That(exception.Message, Is.EqualTo("Cannot load game because file NonexistentHouse does not exist"));
+            });
+        }
+
+        [TestCase("")]
+        [TestCase(" ")]
+        [TestCase("my file")]
+        [TestCase(" myFile")]
+        [TestCase("myFile ")]
+        [TestCase("\\")]
+        [TestCase("\\myFile")]
+        [TestCase("myFile\\")]
+        [TestCase("my\\File")]
+        [TestCase("/")]
+        [TestCase("/myFile")]
+        [TestCase("myFile/")]
+        [TestCase("my/File")]
+        [Category("SavedGame HouseFileName Failure")]
+        public void Test_SavedGame_SetHouseFileName_ToInvalidValue_InvalidFileName(string fileName)
+        {
+            Assert.Multiple(() =>
+            {
+                // Assert that creating a SavedGame object with an invalid file name raises an exception
+                var exception = Assert.Throws<InvalidDataException>(() =>
+                {
+                    SavedGame savedGame = new SavedGame()
+                    {
+                        HouseFileName = fileName,
+                        PlayerLocation = "Entry",
+                        MoveNumber = 1,
+                        OpponentsAndHidingLocations = validOpponentsAndHidingPlacesDictionary,
+                        FoundOpponents = new List<string>()
+                    };
+                });
+
+                // Assert that exception message is as expected
+                Assert.That(exception.Message, Is.EqualTo($"Cannot perform action because file name \"{fileName}\" is invalid (is empty or contains illegal characters, e.g. \\, /, or whitespace)"));
             });
         }
 


### PR DESCRIPTION
FileExtensions.cs
-edit: throw InvalidDataException is file name passed into GetFullFileNameForJson is isvalid

GameController.cs
-edit: invalid file name returns message including file name passed into ParseInput method
-edit: add separate message if empty file name passed into ParseInput method

FileExtensionTests.cs
-add: test that GetFullFileNameForJson throws an exception when invalid file name passed in

GameControllerSaveGameTests.cs
-add: separate test to check message returned when empty file name entered into ParseInput

SavedGameTests.cs
-add: test HouseFileName setter when invalid file name passed in -fix: change TestCase to Test