### PR TITLE
Allow user to input direction shorthands to navigate

### DIFF
--- a/HideAndSeekClassLibrary/Direction.cs
+++ b/HideAndSeekClassLibrary/Direction.cs
@@ -121,16 +121,25 @@
         };
 
         /// <summary>
-        /// Parse Direction from string (not case sensitive)
+        /// Parse Direction from text (not case sensitive)
         /// (checks for direction as text and shorthand for direction)
         /// </summary>
         /// <param name="directionText">Direction as text or shorthand for direction</param>
-        /// <returns>Direction if successfully parsed, 0 otherwise</returns>
-        public static Direction? Parse(string directionText)
+        /// <param name="direction">Direction if successfully parsed, 0 otherwise</param>
+        /// <returns>True if Direction successfully parsed from text</returns>
+        public static bool TryParse(string directionText, out Direction direction)
         {
-            directionText = directionText.Trim().ToLower(); // Trim direction text and convert to lowercase
-            TextsForDirections.TryGetValue(directionText, out Direction direction); // Set variable to associated Direction
-            return direction; // Return variable
+            // Trim direction text and convert to lowercase
+            directionText = directionText.Trim().ToLower();
+
+            // Attempt to parse direction and set variable to whether parse is successful
+            bool successfulParse = TextsForDirections.TryGetValue(directionText, out Direction parsedDirection);
+            
+            // Set method out variable to Direction parsed
+            direction = parsedDirection;
+
+            // Return whether parse was successful
+            return successfulParse;
         }
     }
 }

--- a/HideAndSeekClassLibrary/Direction.cs
+++ b/HideAndSeekClassLibrary/Direction.cs
@@ -32,6 +32,7 @@
 
     /// <summary>
     /// Extension class for Direction enum to describe a direction or get the opposite direction
+    /// Also includes static method to convert a string to a direction
     /// 
     /// CREDIT: adapted from Stellman and Greene's code
     /// </summary>
@@ -85,6 +86,51 @@
             {
                 return $"to the {direction}"; // Return extra words with direction
             }
+        }
+
+        /// <summary>
+        /// Text values (all lowercase) for Directions
+        /// (key is text value written out or shorthand, value is associated Direction)
+        /// </summary>
+        public static readonly IDictionary<string, Direction> TextsForDirections = new Dictionary<string, Direction>()
+        {
+            { "north", Direction.North },
+            { "n", Direction.North },
+            { "south", Direction.South },
+            { "s", Direction.South },
+            { "east", Direction.East },
+            { "e", Direction.East },
+            { "west", Direction.West },
+            { "w", Direction.West },
+            { "northeast", Direction.Northeast },
+            { "ne", Direction.Northeast },
+            { "southwest", Direction.Southwest },
+            { "sw", Direction.Southwest },
+            { "southeast", Direction.Southeast },
+            { "se", Direction.Southeast },
+            { "northwest", Direction.Northwest },
+            { "nw", Direction.Northwest },
+            { "up", Direction.Up },
+            { "u", Direction.Up },
+            { "down", Direction.Down },
+            { "d", Direction.Down },
+            { "in", Direction.In },
+            { "i", Direction.In },
+            { "out", Direction.Out },
+            { "o", Direction.Out }
+        };
+
+        /// <summary>
+        /// Parse Direction from string (not case sensitive)
+        /// (checks for direction as text and shorthand for direction)
+        /// </summary>
+        /// <param name="directionText">Direction as text or shorthand for direction</param>
+        /// <returns>Direction if successfully parsed, 0 otherwise</returns>
+        public static Direction? Parse(string directionText)
+        {
+            directionText = directionText.Trim().ToLower(); // Trim direction text and convert to lowercase
+            TextsForDirections.TryGetValue(directionText, out Direction direction); // Set variable to associated Direction
+            return direction; // Return variable
         }
     }
 }

--- a/HideAndSeekClassLibrary/Direction.cs
+++ b/HideAndSeekClassLibrary/Direction.cs
@@ -34,18 +34,17 @@
     /// Extension class for Direction enum to describe a direction or get the opposite direction
     /// Also includes static method to convert a string to a direction
     /// 
-    /// CREDIT: adapted from Stellman and Greene's code
+    /// CREDIT: Direction descriptions and description logic adapted from Stellman and Greene's code
     /// </summary>
 
     /** CREDIT
-     *  direction descriptions and directions description logic
+     *  direction descriptions and direction description logic
      *  adapted from HideAndSeek project's Location class's DescribeDirection method
      *  © 2023 Andrew Stellman and Jennifer Greene
      *         Published under the MIT License
      *         https://github.com/head-first-csharp/fourth-edition/blob/master/Code/Chapter_10/HideAndSeek_part_3/HideAndSeek/Direction.cs
      *         Link valid as of 02-25-2025
      * **/
-
     public static class DirectionExtensions
     {
         /// <summary>

--- a/HideAndSeekClassLibrary/GameController.cs
+++ b/HideAndSeekClassLibrary/GameController.cs
@@ -332,7 +332,7 @@ namespace HideAndSeek
                     return "Cannot perform action because no file name was entered"; // Return failure message
                 }
             }
-            else if ( !(Enum.TryParse(originalCommand, out Direction direction)) ) // If input cannot be parsed to Direction enum value
+            else if ( !(DirectionExtensions.TryParse(originalCommand, out Direction direction)) ) // If input cannot be parsed to Direction enum value
             {
                 return "That's not a valid direction"; // Return invalid direction message
             }

--- a/HideAndSeekTestProject/TestDirectionExtensions.cs
+++ b/HideAndSeekTestProject/TestDirectionExtensions.cs
@@ -54,5 +54,54 @@ namespace HideAndSeek
         {
             Assert.That(direction.DirectionDescription(), Is.EqualTo(expectedText));
         }
+
+        [TestCase("north", Direction.North)]
+        [TestCase("n", Direction.North)]
+        [TestCase("south", Direction.South)]
+        [TestCase("s", Direction.South)]
+        [TestCase("east", Direction.East)]
+        [TestCase("e", Direction.East)]
+        [TestCase("west", Direction.West)]
+        [TestCase("w", Direction.West)]
+        [TestCase("northeast", Direction.Northeast)]
+        [TestCase("ne", Direction.Northeast)]
+        [TestCase("southwest", Direction.Southwest)]
+        [TestCase("sw", Direction.Southwest)]
+        [TestCase("southeast", Direction.Southeast)]
+        [TestCase("se", Direction.Southeast)]
+        [TestCase("northwest", Direction.Northwest)]
+        [TestCase("nw", Direction.Northwest)]
+        [TestCase("up", Direction.Up)]
+        [TestCase("u", Direction.Up)]
+        [TestCase("down", Direction.Down)]
+        [TestCase("d", Direction.Down)]
+        [TestCase("in", Direction.In)]
+        [TestCase("i", Direction.In)]
+        [TestCase("out", Direction.Out)]
+        [TestCase("o", Direction.Out)]
+        public void Test_DirectionExtensions_Parse_Lowercase(string directionText, Direction direction)
+        {
+            Assert.That(DirectionExtensions.Parse(directionText), Is.EqualTo(direction));
+        }
+
+        [TestCase("N")]
+        [TestCase("North")]
+        [TestCase("nOrth")]
+        [TestCase("nOrTh")]
+        [TestCase("NORTH")]
+        public void Test_DirectionExtensions_Parse_MixedCase(string directionText)
+        {
+            Assert.That(DirectionExtensions.Parse(directionText), Is.EqualTo(Direction.North));
+        }
+
+        [TestCase("")]
+        [TestCase(" ")]
+        [TestCase("}{yaeu\\@!//")]
+        [TestCase("No")]
+        [TestCase("Northuperly")]
+        public void Test_DirectionExtensions_Parse_InvalidDirection_ReturnsNull(string directionText)
+        {
+            Assert.That( (int)DirectionExtensions.Parse(directionText), Is.EqualTo(0) );
+        }
     }
 }

--- a/HideAndSeekTestProject/TestDirectionExtensions.cs
+++ b/HideAndSeekTestProject/TestDirectionExtensions.cs
@@ -79,7 +79,8 @@ namespace HideAndSeek
         [TestCase("i", Direction.In)]
         [TestCase("out", Direction.Out)]
         [TestCase("o", Direction.Out)]
-        public void Test_DirectionExtensions_Parse_Lowercase(string directionText, Direction expectedDirection)
+        [Category("DirectionExtensions TryParse Success")]
+        public void Test_DirectionExtensions_TryParse_Lowercase(string directionText, Direction expectedDirection)
         {
             bool parseSuccessful = DirectionExtensions.TryParse(directionText, out Direction actualDirection);
             Assert.Multiple(() =>
@@ -94,7 +95,8 @@ namespace HideAndSeek
         [TestCase("nOrth")]
         [TestCase("nOrTh")]
         [TestCase("NORTH")]
-        public void Test_DirectionExtensions_Parse_MixedCase(string directionText)
+        [Category("DirectionExtensions TryParse Success")]
+        public void Test_DirectionExtensions_TryParse_MixedCase(string directionText)
         {
             bool parseSuccessful = DirectionExtensions.TryParse(directionText, out Direction actualDirection);
             Assert.Multiple(() =>
@@ -109,6 +111,7 @@ namespace HideAndSeek
         [TestCase("}{yaeu\\@!//")]
         [TestCase("No")]
         [TestCase("Northuperly")]
+        [Category("DirectionExtensions TryParse Failure")]
         public void Test_DirectionExtensions_Parse_InvalidDirection(string directionText)
         {
             bool parseSuccessful = DirectionExtensions.TryParse(directionText, out Direction direction);

--- a/HideAndSeekTestProject/TestDirectionExtensions.cs
+++ b/HideAndSeekTestProject/TestDirectionExtensions.cs
@@ -79,9 +79,14 @@ namespace HideAndSeek
         [TestCase("i", Direction.In)]
         [TestCase("out", Direction.Out)]
         [TestCase("o", Direction.Out)]
-        public void Test_DirectionExtensions_Parse_Lowercase(string directionText, Direction direction)
+        public void Test_DirectionExtensions_Parse_Lowercase(string directionText, Direction expectedDirection)
         {
-            Assert.That(DirectionExtensions.Parse(directionText), Is.EqualTo(direction));
+            bool parseSuccessful = DirectionExtensions.TryParse(directionText, out Direction actualDirection);
+            Assert.Multiple(() =>
+            {
+                Assert.That(parseSuccessful, Is.True, "value returned indicating whether parse was successful");
+                Assert.That(actualDirection, Is.EqualTo(expectedDirection), "Direction from out variable");
+            });
         }
 
         [TestCase("N")]
@@ -91,7 +96,12 @@ namespace HideAndSeek
         [TestCase("NORTH")]
         public void Test_DirectionExtensions_Parse_MixedCase(string directionText)
         {
-            Assert.That(DirectionExtensions.Parse(directionText), Is.EqualTo(Direction.North));
+            bool parseSuccessful = DirectionExtensions.TryParse(directionText, out Direction actualDirection);
+            Assert.Multiple(() =>
+            {
+                Assert.That(parseSuccessful, Is.True, "value returned indicating whether parse was successful");
+                Assert.That(actualDirection, Is.EqualTo(Direction.North), "Direction from out variable");
+            });
         }
 
         [TestCase("")]
@@ -99,9 +109,14 @@ namespace HideAndSeek
         [TestCase("}{yaeu\\@!//")]
         [TestCase("No")]
         [TestCase("Northuperly")]
-        public void Test_DirectionExtensions_Parse_InvalidDirection_ReturnsNull(string directionText)
+        public void Test_DirectionExtensions_Parse_InvalidDirection(string directionText)
         {
-            Assert.That( (int)DirectionExtensions.Parse(directionText), Is.EqualTo(0) );
+            bool parseSuccessful = DirectionExtensions.TryParse(directionText, out Direction direction);
+            Assert.Multiple(() =>
+            {
+                Assert.That(parseSuccessful, Is.False, "value returned indicating whether parse was successful");
+                Assert.That( (int)direction, Is.EqualTo(0), "value from out variable cast to int" );
+            });
         }
     }
 }

--- a/HideAndSeekTestProject/TestGameController_ParseInput.cs
+++ b/HideAndSeekTestProject/TestGameController_ParseInput.cs
@@ -169,14 +169,71 @@ namespace HideAndSeek
             House.FileSystem = new FileSystem(); // Set static House file system to new file system
         }
 
+        [TestCase("north", "south", "east", "west", "northeast", "southwest", "southeast", "northwest", "up", "down", "in", "out")]
+        [TestCase("n", "s", "e", "w", "ne", "sw", "se", "nw", "u", "d", "i", "o")]
+        public void Test_GameController_ParseInput_Move_InLowercaseDirection_AndCheckMessage(
+            string north, string south, string east, string west, string northeast, string southwest, 
+            string southeast, string northwest, string up, string down, string inText, string outText)
+        {
+            Assert.Multiple(() =>
+            {
+                // Go Out to Garage
+                Assert.That(gameController.ParseInput(outText), Is.EqualTo("Moving Out"), "Out to Garage");
+
+                // Go In to Entry
+                Assert.That(gameController.ParseInput(inText), Is.EqualTo("Moving In"), "In to Entry");
+
+                // Go East to Hallway
+                Assert.That(gameController.ParseInput(east), Is.EqualTo("Moving East"), "East to Hallway");
+
+                // Go North to Bathroom
+                Assert.That(gameController.ParseInput(north), Is.EqualTo("Moving North"), "North to Bathroom");
+
+                // Go South to Hallway
+                Assert.That(gameController.ParseInput(south), Is.EqualTo("Moving South"), "South to Hallway");
+
+                // Go Northwest to Kitchen
+                Assert.That(gameController.ParseInput(northwest), Is.EqualTo("Moving Northwest"), "Northwest to Kitchen");
+
+                // Go Southeast to Hallway
+                Assert.That(gameController.ParseInput(southeast), Is.EqualTo("Moving Southeast"), "Southeast to Hallway");
+
+                // Go Up to Landing
+                Assert.That(gameController.ParseInput(up), Is.EqualTo("Moving Up"), "Up to Landing");
+
+                // Go Southwest to Nursery
+                Assert.That(gameController.ParseInput(southwest), Is.EqualTo("Moving Southwest"), "Southwest to Nursery");
+
+                // Go Northeast to Landing
+                Assert.That(gameController.ParseInput(northeast), Is.EqualTo("Moving Northeast"), "Northeast to Landing");
+
+                // Go Down to Hallway
+                Assert.That(gameController.ParseInput(down), Is.EqualTo("Moving Down"), "Down to Hallway");
+
+                // Go West to Entry
+                Assert.That(gameController.ParseInput(west), Is.EqualTo("Moving West"), "West to Entry");
+            });
+        }
+
+        [TestCase("E")]
+        [TestCase("East")]
+        [TestCase("eAst")]
+        [TestCase("eASt")]
+        [TestCase("EAST")]
+        [Category("GameController ParseInput Move Message Success")]
+        public void Test_GameController_ParseInput_Move_InMixedCaseDirection_AndCheckMessage(string directionText)
+        {
+            Assert.That(gameController.ParseInput(directionText), Is.EqualTo("Moving East"));
+        }
+
         [Test]
         [Category("GameController ParseInput Move Message Status Success")]
-        public void Test_GameController_ParseInput_Move_AndCheckMessageAndStatus()
+        public void Test_GameController_ParseInput_Move_InCapitalizedDirection_AndCheckMessageAndStatus()
         {
             Assert.Multiple(() =>
             {
                 // Move East from Entry to Hallway.
-                Assert.That(gameController.ParseInput("East"), Is.EqualTo("Moving East"), "parsing \"East\" from Entry returns appropriate text");
+                Assert.That(gameController.ParseInput("EAST"), Is.EqualTo("Moving East"), "parsing \"East\" from Entry returns appropriate text");
                 Assert.That(gameController.Status, Is.EqualTo("You are in the Hallway. You see the following exits:" +
                     Environment.NewLine + " - the Landing is Up" +
                     Environment.NewLine + " - the Bathroom is to the North" +
@@ -186,7 +243,7 @@ namespace HideAndSeek
                     Environment.NewLine + "You have not found any opponents"), "game status appropriately changed to text for Hallway");
 
                 // Move Up from Hallway to Landing.
-                Assert.That(gameController.ParseInput("Up"), Is.EqualTo("Moving Up"), "parsing \"Up\" from Hallway returns appropriate text");
+                Assert.That(gameController.ParseInput("UP"), Is.EqualTo("Moving Up"), "parsing \"Up\" from Hallway returns appropriate text");
                 Assert.That(gameController.Status, Is.EqualTo("You are in the Landing. You see the following exits:" +
                     Environment.NewLine + " - the Attic is Up" +
                     Environment.NewLine + " - the Kids Room is to the Southeast" +
@@ -198,7 +255,7 @@ namespace HideAndSeek
                     Environment.NewLine + "You have not found any opponents"), "game status appropriately changed to text for Landing");
 
                 // Move Northwest from Landing to Master Bedroom.
-                Assert.That(gameController.ParseInput("Northwest"), Is.EqualTo("Moving Northwest"), "parsing \"Northwest\" from Landing returns appropriate text");
+                Assert.That(gameController.ParseInput("NORTHWEST"), Is.EqualTo("Moving Northwest"), "parsing \"Northwest\" from Landing returns appropriate text");
                 Assert.That(gameController.Status, Is.EqualTo("You are in the Master Bedroom. You see the following exits:" +
                     Environment.NewLine + " - the Landing is to the Southeast" +
                     Environment.NewLine + " - the Master Bath is to the East" +
@@ -206,7 +263,7 @@ namespace HideAndSeek
                     Environment.NewLine + "You have not found any opponents"), "game status appropriately changed to text for Master Bedroom");
 
                 // Move East from Master Bedroom to Master Bath.
-                Assert.That(gameController.ParseInput("East"), Is.EqualTo("Moving East"), "parsing \"East\" from Master Bedroom returns appropriate text");
+                Assert.That(gameController.ParseInput("EAST"), Is.EqualTo("Moving East"), "parsing \"East\" from Master Bedroom returns appropriate text");
                 Assert.That(gameController.Status, Is.EqualTo("You are in the Master Bath. You see the following exits:" +
                     Environment.NewLine + " - the Master Bedroom is to the West" +
                     Environment.NewLine + "Someone could hide in the tub" +
@@ -214,15 +271,19 @@ namespace HideAndSeek
             });
         }
 
-        [Test]
+        [TestCase("")]
+        [TestCase(" ")]
+        [TestCase("}{yaeu\\@!//")]
+        [TestCase("No")]
+        [TestCase("Northuperly")]
         [Category("GameController ParseInput Move Message Status Failure")]
-        public void Test_GameController_ParseInput_Move_InInvalidDirection_AndCheckMessageAndStatus()
+        public void Test_GameController_ParseInput_Move_InInvalidDirection_AndCheckMessageAndStatus(string directionText)
         {
             string initialStatus = gameController.Status;
 
             Assert.Multiple(() =>
             {
-                Assert.That(gameController.ParseInput("X"), Is.EqualTo("That's not a valid direction"), "parsing \"X\" returns invalid direction error message");
+                Assert.That(gameController.ParseInput(directionText), Is.EqualTo("That's not a valid direction"), "parsing \"X\" returns invalid direction error message");
                 Assert.That(gameController.Status, Is.EqualTo(initialStatus), "game status does not change");
             });
         }

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ If there is a problem loading the house layout, you will see an error message an
 
 <a name="usage-move"></a>
 ### Move in specific direction
-Move in any of the directions listed in the exit list (right below the "You see the following exits:" text) by typing the direction and pressing the Enter key on your keyboard. (This counts as a move!)
+Move in any of the directions listed in the exit list (right below the "You see the following exits:" text) by typing the direction (or direction shorthand*) and pressing the Enter key on your keyboard. (This counts as a move!)
 
 For example, when you're in the Garage, you could type "In" and press the Enter key to move to the Entry.
 ```
@@ -121,6 +121,22 @@ Someone could hide behind the car
 You have not found any opponents
 2: Which direction do you want to go (or type 'check'): In
 ```
+
+*Direction shorthands:
+| Shorthand | Direction |
+| --------- | ------------ |
+|  ```U```  |      Up      |
+|  ```D```  |     Down     |
+|  ```I```  |      In      |
+|  ```O```  |     Out      |
+|  ```N```  |     North    |
+|  ```S```  |     South    |
+|  ```E```  |     East     |
+|  ```W```  |     West     |
+|  ```NE``` |   Northeast  |
+|  ```NW``` |   Northwest  |
+|  ```SE``` |   Southeast  |
+|  ```SW``` |   Southwest  |
 
 
 <a name="usage-check"></a>


### PR DESCRIPTION
Allow user to input direction shorthands (e.g. E, SE, N, NW, etc.) to move through house