### PR TITLE
Throw appropriate exception types from methods and properties in classes

### DIFF
--- a/HideAndSeekClassLibrary/Direction.cs
+++ b/HideAndSeekClassLibrary/Direction.cs
@@ -134,7 +134,7 @@
             // Attempt to parse direction, if parse unsuccessful
             if( !(TextsForDirections.TryGetValue(directionText, out Direction parsedDirection)) )
             {
-                throw new ArgumentException("That's not a valid direction"); // Throw new exception with custom error message
+                throw new ArgumentException("That's not a valid direction", nameof(directionText)); // Throw new exception with custom error message
             }
 
             // Return whether parse was successful

--- a/HideAndSeekClassLibrary/FileExtensions.cs
+++ b/HideAndSeekClassLibrary/FileExtensions.cs
@@ -32,7 +32,7 @@ namespace HideAndSeek
             // If file name is invalid
             if( !(fileSystem.IsValidName(fileName)) )
             {
-                throw new ArgumentException($"Cannot perform action because file name \"{fileName}\" is invalid (is empty or contains illegal characters, e.g. \\, /, or whitespace)");
+                throw new ArgumentException($"Cannot perform action because file name \"{fileName}\" is invalid (is empty or contains illegal characters, e.g. \\, /, or whitespace)", nameof(fileName));
             }
 
             // Return file name with extension

--- a/HideAndSeekClassLibrary/FileExtensions.cs
+++ b/HideAndSeekClassLibrary/FileExtensions.cs
@@ -26,13 +26,13 @@ namespace HideAndSeek
         /// <param name="fileSystem"></param>
         /// <param name="fileName">Name of file not including extension</param>
         /// <returns>Full name of file including extension</returns>
-        /// <exception cref="InvalidDataException">Exception thrown if file name is invalid</exception>
+        /// <exception cref="ArgumentException">Exception thrown if file name is invalid</exception>
         public static string GetFullFileNameForJson(this IFileSystem fileSystem, string fileName)
         {
             // If file name is invalid
             if( !(fileSystem.IsValidName(fileName)) )
             {
-                throw new InvalidDataException($"Cannot perform action because file name \"{fileName}\" is invalid (is empty or contains illegal characters, e.g. \\, /, or whitespace)");
+                throw new ArgumentException($"Cannot perform action because file name \"{fileName}\" is invalid (is empty or contains illegal characters, e.g. \\, /, or whitespace)");
             }
 
             // Return file name with extension

--- a/HideAndSeekClassLibrary/GameController.cs
+++ b/HideAndSeekClassLibrary/GameController.cs
@@ -395,6 +395,7 @@ namespace HideAndSeek
         /// </summary>
         /// <param name="fileName">Name of file in which to save game data</param>
         /// <returns>String describing what happened</returns>
+        /// <exception cref="ArgumentException">Exception thrown if file name is invalid</exception>
         /// <exception cref="InvalidOperationException">Exception thrown if file already exists</exception>
         public string SaveGame(string fileName)
         {
@@ -430,6 +431,7 @@ namespace HideAndSeek
         /// </summary>
         /// <param name="fileName">Name of file from which to load game data</param>
         /// <returns>String describing what happened</returns>
+        /// <exception cref="ArgumentException">Exception thrown if file name is invalid</exception>
         /// <exception cref="JsonException">Exception thrown if JSON formatting issue</exception>
         /// <exception cref="InvalidDataException">Exception thrown if invalid property value</exception>
         /// <exception cref="InvalidOperationException">Exception thrown if invalid operation</exception>
@@ -468,6 +470,10 @@ namespace HideAndSeek
             catch(InvalidOperationException e) // If problem due to attempted invalid operation
             {
                 throw new InvalidOperationException($"Cannot process because data is corrupt - {e.Message}"); // Throw new exception with custom error message
+            }
+            catch (ArgumentException e) // If problem due to invalid argument (e.g. House file name is invalid)
+            {
+                throw new ArgumentException($"Cannot process because data is corrupt - {e.Message}"); // Throw new exception with custom error message
             }
             catch (NullReferenceException e)
             {
@@ -537,6 +543,7 @@ namespace HideAndSeek
         /// </summary>
         /// <param name="fileName">Name of file to delete</param>
         /// <returns>String describing what happened</returns>
+        /// <exception cref="ArgumentException">Exception thrown if file name is invalid</exception>
         /// <exception cref="FileNotFoundException">Exception thrown if file not found</exception>
         public string DeleteGame(string fileName)
         {

--- a/HideAndSeekClassLibrary/GameController.cs
+++ b/HideAndSeekClassLibrary/GameController.cs
@@ -172,7 +172,7 @@ namespace HideAndSeek
             if(numberOfOpponents < 1 || numberOfOpponents > DefaultOpponentNames.Length)
             {
                 throw new ArgumentException("Cannot create a new instance of GameController " +
-                                            "because the number of Opponents specified is invalid (must be between 1 and 10)"); // Throw exception
+                                            "because the number of Opponents specified is invalid (must be between 1 and 10)", nameof(numberOfOpponents)); // Throw exception
             }
 
             // Set up initial game with specific Opponent names and House file name
@@ -190,7 +190,7 @@ namespace HideAndSeek
             // If no opponent names in array
             if(opponentNames.Length == 0)
             {
-                throw new ArgumentException("Cannot create a new instance of GameController because no names for Opponents were passed in"); // Throw exception
+                throw new ArgumentException("Cannot create a new instance of GameController because no names for Opponents were passed in", nameof(opponentNames)); // Throw exception
             }
 
             // Set up initial game with specific Opponent names and House file name
@@ -328,7 +328,7 @@ namespace HideAndSeek
             MoveNumber++;
 
             // Attempt to move in specified direction
-            CurrentLocation = CurrentLocation.GetExit(direction);
+            CurrentLocation = CurrentLocation.GetExit(direction); // Throws exception if no exit in specified Direction
 
             // Return description
             return $"Moving {direction}";
@@ -433,10 +433,9 @@ namespace HideAndSeek
         /// </summary>
         /// <param name="fileName">Name of file from which to load game data</param>
         /// <returns>String describing what happened</returns>
-        /// <exception cref="ArgumentException">Exception thrown if file name is invalid</exception>
+        /// <exception cref="ArgumentException">Exception thrown if file name or value in file is invalid</exception>
         /// <exception cref="JsonException">Exception thrown if JSON formatting issue</exception>
-        /// <exception cref="InvalidDataException">Exception thrown if invalid property value</exception>
-        /// <exception cref="InvalidOperationException">Exception thrown if invalid operation</exception>
+        /// <exception cref="InvalidOperationException">Exception thrown if invalid operation attempted</exception>
         /// <exception cref="FileNotFoundException">Exception thrown if saved game file not found</exception>
         /// <exception cref="NullReferenceException">Exception thrown if a reference is null</exception>
         public string LoadGame(string fileName)
@@ -465,19 +464,20 @@ namespace HideAndSeek
             {
                 throw new JsonException($"Cannot process because data is corrupt - {e.Message}"); // Throw new exception with custom error message
             }
-            catch(InvalidDataException e) // If problem due to invalid property value
-            {
-                throw new InvalidDataException($"Cannot process because data is corrupt - {e.Message}"); // Throw new exception with custom error message
-            }
             catch(InvalidOperationException e) // If problem due to attempted invalid operation
             {
                 throw new InvalidOperationException($"Cannot process because data is corrupt - {e.Message}"); // Throw new exception with custom error message
             }
-            catch (ArgumentException e) // If problem due to invalid argument (e.g. House file name is invalid)
+            catch(ArgumentOutOfRangeException e) // If problem due to value out of required range (e.g. MoveNumber not positive)
             {
-                throw new ArgumentException($"Cannot process because data is corrupt - {e.Message}"); // Throw new exception with custom error message
+                string message = $"Cannot process because data is corrupt - {e.Message}";
+                throw new ArgumentOutOfRangeException(e.ParamName, $"Cannot process because data is corrupt - {e.Message}"); // Throw new exception with custom error message
             }
-            catch (NullReferenceException e)
+            catch(ArgumentException e) // If problem due to invalid argument (e.g. House file name is invalid)
+            {
+                throw new ArgumentException($"Cannot process because data is corrupt - {e.Message}", e.ParamName); // Throw new exception with custom error message
+            }
+            catch(NullReferenceException e)
             {
                 if(e.Message == "House has not been set") // If SavedGame House property has not been set
                 {

--- a/HideAndSeekClassLibrary/GameController.cs
+++ b/HideAndSeekClassLibrary/GameController.cs
@@ -165,13 +165,14 @@ namespace HideAndSeek
         /// </summary>
         /// <param name="numberOfOpponents">Number of Opponents to hide in House</param>
         /// <param name="houseFileName">Name of file from which to load House layout</param>
+        /// <exception cref="ArgumentException">Exception thrown when number of Opponents is invalid</exception>
         public GameController(int numberOfOpponents, string houseFileName = "DefaultHouse")
         {
             // If number of Opponents invalid
             if(numberOfOpponents < 1 || numberOfOpponents > DefaultOpponentNames.Length)
             {
                 throw new ArgumentException("Cannot create a new instance of GameController " +
-                                                      "because the number of Opponents specified is invalid (must be between 1 and 10)"); // Throw exception
+                                            "because the number of Opponents specified is invalid (must be between 1 and 10)"); // Throw exception
             }
 
             // Set up initial game with specific Opponent names and House file name
@@ -183,6 +184,7 @@ namespace HideAndSeek
         /// </summary>
         /// <param name="opponentNames">Names of Opponents to hide in House</param>
         /// <param name="houseFileName">Name of file from which to load House layout</param>
+        /// <exception cref="ArgumentException">Exception thrown when no names for Opponents were passed in</exception>"
         public GameController(string[] opponentNames, string houseFileName = "DefaultHouse")
         {
             // If no opponent names in array
@@ -278,6 +280,7 @@ namespace HideAndSeek
         /// </summary>
         /// <param name="hidingPlaces">Names of hiding places for Opponents</param>
         /// <returns>GameController after Opponents rehidden</returns>
+        /// <exception cref="ArgumentOutOfRangeException">Exception thrown if the number of hiding places is not equal to the number of Opponents</exception>
         public GameController RehideAllOpponents(IEnumerable<string> hidingPlaces)
         {
             // Initialize variable for LocationWithHidingPlace objects to empty list
@@ -319,7 +322,6 @@ namespace HideAndSeek
         /// <param name="direction">The Direction to move</param>
         /// <returns>Description</returns>
         /// <exception cref="InvalidOperationException">Exception thrown when no exit in specified Direction</exception>
-        /// <exception cref="ArgumentException">Exception thrown if Direction is invalid</exception>
         public string Move(Direction direction)
         {
             // Increment move number
@@ -342,7 +344,7 @@ namespace HideAndSeek
         /// <exception cref="ArgumentException">Exception thrown if direction is invalid</exception>
         public string Move(string direction)
         {
-            return Move(DirectionExtensions.Parse(direction));
+            return Move( DirectionExtensions.Parse(direction) );
         }
 
         /// <summary>
@@ -486,7 +488,7 @@ namespace HideAndSeek
                     throw; // Bubble up exception
                 }
             }
-            catch(Exception e)
+            catch(Exception)
             {
                 throw; // Bubble up exception
             }

--- a/HideAndSeekClassLibrary/House.cs
+++ b/HideAndSeekClassLibrary/House.cs
@@ -71,6 +71,7 @@ namespace HideAndSeek
         /// </summary>
         /// <param name="fileName">Name of House file (not including .json extension)</param>
         /// <returns>House object created from file</returns>
+        /// <exception cref="ArgumentException">Exception thrown if House file name is invalid</exception>
         /// <exception cref="FileNotFoundException">Exception thrown if House file not found</exception>
         /// <exception cref="JsonException">Exception thrown if House file data is corrupt</exception>
         /// <exception cref="InvalidOperationException">Exception thrown if House file data is corrupt</exception>
@@ -109,9 +110,9 @@ namespace HideAndSeek
             {
                 throw new InvalidDataException($"Cannot process because data in house layout file {fileName} is invalid - {e.Message}");
             }
-            catch (Exception e)
+            catch (Exception)
             {
-                throw e;
+                throw; // Bubble up exception
             }
 
             // Return House object

--- a/HideAndSeekClassLibrary/House.cs
+++ b/HideAndSeekClassLibrary/House.cs
@@ -396,7 +396,7 @@ namespace HideAndSeek
         /// <returns>True if Location exists</returns>
         public bool DoesLocationExist(string name)
         {
-            return GetLocationByName(name) != null;
+            return Locations.Select((l) => l.Name).ToList().Contains(name);
         }
 
         /// <summary>
@@ -406,7 +406,7 @@ namespace HideAndSeek
         /// <returns>True if LocationWithHidingPlace exists</returns>
         public bool DoesLocationWithHidingPlaceExist(string name)
         {
-            return GetLocationWithHidingPlaceByName(name) != null;
+            return LocationsWithHidingPlaces.Select((l) => l.Name).ToList().Contains(name);
         }
 
         /// <summary>
@@ -414,9 +414,17 @@ namespace HideAndSeek
         /// </summary>
         /// <param name="name">Name of Location</param>
         /// <returns>Location with specified name (or null if not found)</returns>
+        /// <exception cref="InvalidOperationException">Exception thrown if no matching location in House</exception>
         public Location GetLocationByName(string name)
         {
-            return Locations.Where(l => l.Name == name).FirstOrDefault();
+            try
+            {
+                return Locations.Where(l => l.Name == name).First();
+            }
+            catch(InvalidOperationException e)
+            {
+                throw new InvalidOperationException($"location \"{name}\" does not exist in House"); // Throw exception
+            }
         }
 
         /// <summary>
@@ -424,9 +432,17 @@ namespace HideAndSeek
         /// </summary>
         /// <param name="name">Name of LocationWithHidingPlace</param>
         /// <returns>LocationWithHidingPlace with specified name (or null if not found)</returns>
+        /// <exception cref="InvalidOperationException">Exception thrown if no matching location with hiding place in House</exception>
         public LocationWithHidingPlace GetLocationWithHidingPlaceByName(string name)
         {
-            return LocationsWithHidingPlaces.Where((x) => x.Name == name).FirstOrDefault();
+            try
+            {
+                return LocationsWithHidingPlaces.Where(l => l.Name == name).First();
+            }
+            catch (InvalidOperationException e)
+            {
+                throw new InvalidOperationException($"location with hiding place \"{name}\" does not exist in House"); // Throw exception
+            }
         }
 
         /// <summary>

--- a/HideAndSeekClassLibrary/House.cs
+++ b/HideAndSeekClassLibrary/House.cs
@@ -71,9 +71,9 @@ namespace HideAndSeek
         /// </summary>
         /// <param name="fileName">Name of House file (not including .json extension)</param>
         /// <returns>House object created from file</returns>
-        /// <exception cref="ArgumentException">Exception thrown if House file name is invalid</exception>
+        /// <exception cref="ArgumentException">Exception thrown if House file name or file value is invalid</exception>
         /// <exception cref="FileNotFoundException">Exception thrown if House file not found</exception>
-        /// <exception cref="JsonException">Exception thrown if House file data is corrupt</exception>
+        /// <exception cref="JsonException">Exception thrown if JSON formatting issue</exception>
         /// <exception cref="InvalidOperationException">Exception thrown if House file data is corrupt</exception>
         public static House CreateHouse(string fileName)
         {
@@ -98,17 +98,17 @@ namespace HideAndSeek
                 house = JsonSerializer.Deserialize<House>(houseFileText); // Deserialize House
                 house.SetUpHouseAfterDeserialization(); // Set up House after deserialization
             }
-            catch (JsonException e)
+            catch (JsonException e) // If JSON format is corrupt
             {
                 throw new JsonException($"Cannot process because data in house layout file {fileName} is corrupt - {e.Message}");
             }
-            catch (InvalidOperationException e)
+            catch (InvalidOperationException e) // If invalid operation attempted
             {
                 throw new InvalidOperationException($"Cannot process because data in house layout file {fileName} is corrupt - {e.Message}");
             }
-            catch (InvalidDataException e)
+            catch (ArgumentException e) // If argument is invalid
             {
-                throw new InvalidDataException($"Cannot process because data in house layout file {fileName} is invalid - {e.Message}");
+                throw new ArgumentException($"Cannot process because data in house layout file {fileName} is invalid - {e.Message}", e.ParamName);
             }
             catch (Exception)
             {
@@ -124,6 +124,7 @@ namespace HideAndSeek
         /// <summary>
         /// Name of House
         /// </summary>
+        /// <exception cref="ArgumentException">Exception thrown if value passed to setter is invalid (empty or only whitespace)</exception>
         [JsonRequired]
         public required string Name
         {
@@ -136,7 +137,7 @@ namespace HideAndSeek
                 // If invalid name is entered
                 if (string.IsNullOrWhiteSpace(value))
                 {
-                    throw new InvalidDataException($"Cannot perform action because house name \"{value}\" is invalid (is empty or contains only whitespace)"); // Throw exception
+                    throw new ArgumentException($"house name \"{value}\" is invalid (is empty or contains only whitespace)", "value"); // Throw exception
                 }
 
                 // Set backing field
@@ -149,6 +150,7 @@ namespace HideAndSeek
         /// <summary>
         /// Name of file from which House is loaded (not including JSON extension)
         /// </summary>
+        /// <exception cref="ArgumentException">Exception thrown if value passed to setter is invalid (empty, illegal characters, whitespace)</exception>
         [JsonRequired]
         public required string HouseFileName
         {
@@ -159,9 +161,10 @@ namespace HideAndSeek
             set
             {
                 // If file name is invalid
-                if (!(FileSystem.IsValidName(value)))
+                if( !(FileSystem.IsValidName(value)) )
                 {
-                    throw new InvalidDataException($"Cannot perform action because house file name \"{value}\" is invalid (is empty or contains illegal characters, e.g. \\, /, or whitespace)"); // Throw exception
+                    throw new ArgumentException(
+                        $"house file name \"{value}\" is invalid (is empty or contains illegal characters, e.g. \\, /, or whitespace)", "value"); // Throw exception
                 }
 
                 // Set backing field
@@ -174,6 +177,7 @@ namespace HideAndSeek
         /// <summary>
         /// Player starting point in House as string
         /// </summary>
+        /// <exception cref="ArgumentException">Exception thrown if value passed to setter is invalid (empty of contains whitespace)</exception>
         [JsonRequired]
         public required string PlayerStartingPoint
         {
@@ -186,7 +190,8 @@ namespace HideAndSeek
                 // If invalid Location name is entered
                 if (string.IsNullOrWhiteSpace(value))
                 {
-                    throw new InvalidDataException($"Cannot perform action because player starting point location name \"{value}\" is invalid (is empty or contains only whitespace)"); // Throw exception
+                    throw new ArgumentException(
+                        $"player starting point location name \"{value}\" is invalid (is empty or contains only whitespace)", "value"); // Throw exception
                 }
 
                 // Set backing field
@@ -199,6 +204,7 @@ namespace HideAndSeek
         /// <summary>
         /// Player starting point in House
         /// </summary>
+        /// <exception cref="InvalidOperationException">Exception thrown if value passed to setter is not in House</exception>
         [JsonIgnore]
         public Location StartingPoint
         {
@@ -208,10 +214,10 @@ namespace HideAndSeek
             }
             set
             {
-                // If Location does not exist in House
-                if ( !(DoesLocationExist(value.Name)) )
+                // If Location is null or does not exist in House
+                if ( value == null || !(DoesLocationExist(value.Name)) )
                 {
-                    throw new InvalidDataException($"Cannot perform action because player starting point location \"{value}\" is not a location in the house"); // Throw exception
+                    throw new InvalidOperationException($"player starting point location \"{value}\" does not exist in House"); // Throw exception
                 }
 
                 // Set backing field and property for JSON serialization
@@ -231,6 +237,7 @@ namespace HideAndSeek
         /// <summary>
         /// List of all LocationWithHidingPlace objects in House
         /// </summary>
+        /// <exception cref="ArgumentException">Exception thrown if value passed to setter is empty list</exception>
         [JsonRequired]
         public IEnumerable<LocationWithHidingPlace> LocationsWithHidingPlaces
         {
@@ -243,7 +250,7 @@ namespace HideAndSeek
                 // If enumerable is empty
                 if(value.Count() == 0)
                 {
-                    throw new InvalidDataException("Cannot perform action because locations with hiding places list is empty"); // Throw exception
+                    throw new ArgumentException("locations with hiding places list is empty", "value"); // Throw exception
                 }
 
                 // Set backing field
@@ -256,6 +263,7 @@ namespace HideAndSeek
         /// <summary>
         /// List of all Locations in House
         /// </summary>
+        /// <exception cref="ArgumentException">Exception thrown if value passed to setter is empty list</exception>
         [JsonIgnore]
         public IEnumerable<Location> Locations
         {
@@ -268,7 +276,7 @@ namespace HideAndSeek
                 // If enumerable is empty
                 if(value.Count() == 0)
                 {
-                    throw new InvalidDataException("Cannot perform action because locations list is empty"); // Throw exception
+                    throw new ArgumentException("locations list is empty", "value"); // Throw exception
                 }
 
                 // Set backing field
@@ -295,6 +303,7 @@ namespace HideAndSeek
         /// <param name="playerStartingPoint">Name of Location where player should start a new game</param>
         /// <param name="locationsWithoutHidingPlaces">Enumerable of Location objects (without hiding places)</param>
         /// <param name="locationsWithHidingPlaces">Enumerable of LocationWithHidingPlace objects</param>
+        /// <exception cref="InvalidOperationException">Exception thrown if player starting location is not in House</exception>
         [SetsRequiredMembers]
         public House(string name, string houseFileName, string playerStartingPoint, 
                      IEnumerable<Location> locationsWithoutHidingPlaces, 
@@ -315,29 +324,34 @@ namespace HideAndSeek
         /// Helper method to set Locations and StartingPoint properties
         /// after LocationsWithoutHidingPlaces and LocationsWithHidingPlaces are set
         /// </summary>
+        /// <exception cref="InvalidOperationException">Exception thrown if player starting location is not in House</exception>
         private void SetLocationsAndStartingPoint()
         {
             // Set list of all Locations in House
             Locations = LocationsWithHidingPlaces.Concat(LocationsWithoutHidingPlaces).ToList();
 
-            // Attempt to get player starting point location
-            Location startingPoint = GetLocationByName(PlayerStartingPoint);
+            // Declare variable to store starting point
+            Location startingPoint;
 
-            // If starting point is not in House
-            if(startingPoint == null)
+            try
             {
-                throw new InvalidDataException($"Cannot perform action because player starting point location \"{PlayerStartingPoint}\" is not a location in the house"); // Throw exception
-            }
+                // Attempt to get player starting point location
+                startingPoint = GetLocationByName(PlayerStartingPoint);
 
-            // Set StartingPoint
-            StartingPoint = startingPoint;
+                // Set StartingPoint
+                StartingPoint = startingPoint;
+            }
+            catch (InvalidOperationException e)
+            {
+                throw new InvalidOperationException($"player starting point location \"{PlayerStartingPoint}\" does not exist in House"); // Throw exception
+            }
         }
 
         /// <summary>
         /// Set up House after deserialization
         /// (set Locations, StartingPoint, and Exits property for each Location in House)
         /// </summary>
-        /// <exception cref="InvalidDataException">Exception thrown if exit Location does not exist</exception>
+        /// <exception cref="InvalidOperationException">Exception thrown if a Location does not exist in House</exception>
         private void SetUpHouseAfterDeserialization()
         {
             // Set Locations and StartingPoint properties
@@ -349,18 +363,21 @@ namespace HideAndSeek
                 // Initialize empty Dictionary to store exits
                 IDictionary<Direction, Location> exitsDictionary = new Dictionary<Direction, Location>();
 
+                // Declare variable to store exit location
+                Location exitLocation;
+
                 // For each exit
                 foreach (KeyValuePair<Direction, string> exit in location.ExitsForSerialization)
                 {
-                    // Get exit Location object
-                    Location exitLocation = GetLocationByName(exit.Value);
-                    
-                    // If exit Location does not exist
-                    if(exitLocation == null)
+                    try
                     {
-                        throw new InvalidDataException(
-                            $"Cannot perform action because \"{location.Name}\" exit location \"{exit.Value}\" " +
-                            $"in direction \"{exit.Key}\" does not exist"); // Throw exception
+                        // Get exit Location object
+                        exitLocation = GetLocationByName(exit.Value);
+                    }
+                    catch(InvalidOperationException e)
+                    {
+                        throw new InvalidOperationException(
+                            $"\"{location.Name}\" exit location \"{exit.Value}\" in direction \"{exit.Key}\" does not exist"); // Throw exception
                     }
 
                     // Add exit location to Dictionary

--- a/HideAndSeekClassLibrary/Location.cs
+++ b/HideAndSeekClassLibrary/Location.cs
@@ -49,6 +49,7 @@ namespace HideAndSeek
         /// <summary>
         /// The name of this location
         /// </summary>
+        /// <exception cref="ArgumentException">Exception thrown if value passed to setter is invalid (empty or only whitespace)</exception>
         [JsonRequired]
         public required string Name
         {
@@ -61,10 +62,10 @@ namespace HideAndSeek
                 // If invalid name is entered
                 if (string.IsNullOrWhiteSpace(value))
                 {
-                    throw new InvalidDataException($"Cannot perform action because location name \"{value}\" is invalid (is empty or contains only whitespace)"); // Throw exception
+                    throw new ArgumentException($"location name \"{value}\" is invalid (is empty or contains only whitespace)", "value"); // Throw exception
                 }
 
-                // Set name variable
+                // Set backing field
                 _name = value;
             }
         }
@@ -76,6 +77,7 @@ namespace HideAndSeek
         /// (Locations as strings so duplicate Locations 
         /// are not created when multiple linked Locations are restored)
         /// </summary>
+        /// <exception cref="ArgumentException">Exception thrown if value passed to setter contains invalid value (empty or only whitespace)</exception>
         [JsonRequired]
         public IDictionary<Direction, string> ExitsForSerialization
         {
@@ -91,7 +93,8 @@ namespace HideAndSeek
                     // If name is invalid
                     if(string.IsNullOrWhiteSpace(kvp.Value))
                     {
-                        throw new InvalidDataException($"Cannot perform action because location name \"{kvp.Value}\" for exit in direction \"{kvp.Key}\" is invalid (is empty or contains only whitespace"); // Throw exception
+                        throw new ArgumentException(
+                            $"location name \"{kvp.Value}\" for exit in direction \"{kvp.Key}\" is invalid (is empty or contains only whitespace", "value"); // Throw exception
                     }
                 }
 
@@ -139,13 +142,13 @@ namespace HideAndSeek
         /// Should only be called by House method
         /// </summary>
         /// <param name="exits">Dictionary of exits</param>
-        /// <exception cref="InvalidDataException">Exception thrown if dictionary is empty</exception>
+        /// <exception cref="ArgumentException">Exception thrown if exits dictionary is empty</exception>
         public void SetExitsDictionary(IDictionary<Direction, Location> exits)
         {
             // If dictionary is empty
             if(exits.Count() == 0)
             {
-                throw new InvalidDataException($"Cannot perform action because location \"{Name}\" must be assigned at least one exit"); // Throw exception
+                throw new ArgumentException($"location \"{Name}\" must be assigned at least one exit", nameof(exits)); // Throw exception
             }
 
             // Set Exits property

--- a/HideAndSeekClassLibrary/LocationWithHidingPlace.cs
+++ b/HideAndSeekClassLibrary/LocationWithHidingPlace.cs
@@ -59,6 +59,7 @@ namespace HideAndSeek
         /// <summary>
         /// Name of hiding place
         /// </summary>
+        /// <exception cref="ArgumentException">Exception thrown if value passed to setter is invalid (empty or only whitespace)</exception>
         [JsonRequired]
         public required string HidingPlace
         {
@@ -71,7 +72,7 @@ namespace HideAndSeek
                 // If invalid name is entered
                 if (string.IsNullOrWhiteSpace(value))
                 {
-                    throw new InvalidDataException($"Cannot perform action because hiding place \"{value}\" is invalid (is empty or contains only whitespace)"); // Throw exception
+                    throw new ArgumentException($"hiding place \"{value}\" is invalid (is empty or contains only whitespace)", "value"); // Throw exception
                 }
 
                 // Set backing field

--- a/HideAndSeekClassLibrary/Opponent.cs
+++ b/HideAndSeekClassLibrary/Opponent.cs
@@ -39,6 +39,7 @@ namespace HideAndSeek
         /// <summary>
         /// Name of Opponent
         /// </summary>
+        /// <exception cref="ArgumentException">Exception thrown if value passed to setter is invalid (empty or only whitespace)</exception>
         public string Name
         {
             get
@@ -48,9 +49,9 @@ namespace HideAndSeek
             private set
             {
                 // If value is whitespace or empty
-                if(value.Trim().Length == 0)
+                if(value.Trim() == string.Empty)
                 {
-                    throw new InvalidDataException($"Cannot perform action because opponent name \"{value}\" is invalid (is empty or contains only whitespace)");
+                    throw new ArgumentException($"opponent name \"{value}\" is invalid (is empty or contains only whitespace)", "value");
                 }
 
                 // Set name

--- a/HideAndSeekTestProject/TestDirectionExtensions.cs
+++ b/HideAndSeekTestProject/TestDirectionExtensions.cs
@@ -101,8 +101,8 @@ namespace HideAndSeek
         [TestCase("}{yaeu\\@!//")]
         [TestCase("No")]
         [TestCase("Northuperly")]
-        [Category("DirectionExtensions Parse Failure")]
-        public void Test_DirectionExtensions_Parse_InvalidDirection_AndCatchErrorMessage(string directionText)
+        [Category("DirectionExtensions Parse ArgumentException Failure")]
+        public void Test_DirectionExtensions_Parse_AndCatchErrorMessage_ForInvalidDirection(string directionText)
         {
             Assert.Multiple(() =>
             {
@@ -113,7 +113,7 @@ namespace HideAndSeek
                 });
 
                 // Assert that exception message is as expected
-                Assert.That(exception.Message, Is.EqualTo("That's not a valid direction"));
+                Assert.That(exception.Message, Does.StartWith("That's not a valid direction"));
             });
         }
     }

--- a/HideAndSeekTestProject/TestFileExtensions.cs
+++ b/HideAndSeekTestProject/TestFileExtensions.cs
@@ -42,13 +42,13 @@ namespace HideAndSeek
         [TestCase("/myFile")]
         [TestCase("myFile/")]
         [TestCase("my/File")]
-        [Category("FileExtensions GetFullFileNameForJson Failure")]
+        [Category("FileExtensions GetFullFileNameForJson ArgumentException Failure")]
         public void Test_FileExtensions_GetFullFileNameForJson_AndCheckErrorMessage_ForInvalidFileName(string fileName)
         {
             Assert.Multiple(() =>
             {
                 // Assert that getting full file name with invalid file name raises exception
-                var exception = Assert.Throws<InvalidDataException>(() =>
+                var exception = Assert.Throws<ArgumentException>(() =>
                 {
                     fileSystem.GetFullFileNameForJson(fileName);
                 });

--- a/HideAndSeekTestProject/TestFileExtensions.cs
+++ b/HideAndSeekTestProject/TestFileExtensions.cs
@@ -54,7 +54,7 @@ namespace HideAndSeek
                 });
 
                 // Assert that exception message is as expected
-                Assert.That(exception.Message, Is.EqualTo($"Cannot perform action because file name \"{fileName}\" is invalid (is empty or contains illegal characters, e.g. \\, /, or whitespace)"));
+                Assert.That(exception.Message, Does.StartWith($"Cannot perform action because file name \"{fileName}\" is invalid (is empty or contains illegal characters, e.g. \\, /, or whitespace)"));
             });
         }
 

--- a/HideAndSeekTestProject/TestGameController_CheckCurrentLocationAndStatus.cs
+++ b/HideAndSeekTestProject/TestGameController_CheckCurrentLocationAndStatus.cs
@@ -203,8 +203,8 @@ namespace HideAndSeek
         }
 
         [Test]
-        [Category("GameController CheckCurrentLocation FoundOpponents Status MoveNumber GameOver CurrentLocation Failure")]
-        public void Test_GameController_CheckCurrentlocation_InLocationWithoutHidingPlace_AndCheckErrorMessageAndProperties()
+        [Category("GameController CheckCurrentLocation FoundOpponents Status MoveNumber GameOver CurrentLocation InvalidOperationException Failure")]
+        public void Test_GameController_CheckCurrentlocation_AndCheckErrorMessageAndProperties_InLocationWithoutHidingPlace()
         {
             Location initialLocation = gameController.CurrentLocation; // Get initial location before attempt to check
             string initialStatus = gameController.Status; // Get initial status before attempt to check

--- a/HideAndSeekTestProject/TestGameController_CustomHouse.cs
+++ b/HideAndSeekTestProject/TestGameController_CustomHouse.cs
@@ -44,7 +44,7 @@ namespace HideAndSeek
                 });
 
                 // Assert that exception message is as expected
-                Assert.That(exception.Message, Is.EqualTo("Cannot perform action because file name \"@eou]} {(/\" is invalid (is empty or contains illegal characters, e.g. \\, /, or whitespace)"));
+                Assert.That(exception.Message, Does.StartWith("Cannot perform action because file name \"@eou]} {(/\" is invalid (is empty or contains illegal characters, e.g. \\, /, or whitespace)"));
             });
         }
 

--- a/HideAndSeekTestProject/TestGameController_CustomHouse.cs
+++ b/HideAndSeekTestProject/TestGameController_CustomHouse.cs
@@ -32,13 +32,13 @@ namespace HideAndSeek
         }
 
         [TestCaseSource(typeof(TestGameController_CustomHouse_TestData), nameof(TestGameController_CustomHouse_TestData.TestCases_For_Test_GameController_CustomHouse_Constructor_AndCheckErrorMessage_ForInvalidHouseFileName))]
-        [Category("GameController Constructor Failure")]
+        [Category("GameController Constructor ArgumentException Failure")]
         public void Test_GameController_CustomHouse_Constructor_AndCheckErrorMessage_ForInvalidHouseFileName(Action CallWithInvalidHouseFileName)
         {
             Assert.Multiple(() =>
             {
                 // Assert that doing action with name of nonexistent House file raises an exception
-                var exception = Assert.Throws<InvalidDataException>(() =>
+                var exception = Assert.Throws<ArgumentException>(() =>
                 {
                     CallWithInvalidHouseFileName();
                 });

--- a/HideAndSeekTestProject/TestGameController_CustomHouse.cs
+++ b/HideAndSeekTestProject/TestGameController_CustomHouse.cs
@@ -48,8 +48,9 @@ namespace HideAndSeek
             });
         }
 
-        [TestCaseSource(typeof(TestGameController_CustomHouse_TestData), nameof(TestGameController_CustomHouse_TestData.TestCases_For_Test_GameController_CheckErrorMessage_ForHouseFileDoesNotExist))]
-        public void Test_GameController_Constructor_AndCheckErrorMessage_ForHouseFileDoesNotExist(Action CallWithNonexistentFileName)
+        [TestCaseSource(typeof(TestGameController_CustomHouse_TestData), 
+            nameof(TestGameController_CustomHouse_TestData.TestCases_For_Test_GameController_CheckErrorMessage_WhenHouseFileDoesNotExist))]
+        public void Test_GameController_Constructor_AndCheckErrorMessage_WhenHouseFileDoesNotExist(Action CallWithNonexistentFileName)
         {
             Assert.Multiple(() =>
             {
@@ -268,7 +269,8 @@ namespace HideAndSeek
         /// -I added/edited some comments for easier reading.
         /// -I added messages to the assertions to make them easier to debug.
         /// </summary>
-        [TestCaseSource(typeof(TestGameController_CustomHouse_TestData), nameof(TestGameController_CustomHouse_TestData.TestCases_For_Test_GameController_CustomHouse_FullGame_AndCheckMessageAndProperties))]
+        [TestCaseSource(typeof(TestGameController_CustomHouse_TestData), 
+            nameof(TestGameController_CustomHouse_TestData.TestCases_For_Test_GameController_CustomHouse_FullGame_AndCheckMessageAndProperties))]
         public void Test_GameController_CustomHouse_FullGame_AndCheckMessageAndProperties(GameController gameController)
         {
             // Hide Opponents is specific hiding places

--- a/HideAndSeekTestProject/TestGameController_CustomHouse_TestData.cs
+++ b/HideAndSeekTestProject/TestGameController_CustomHouse_TestData.cs
@@ -321,7 +321,7 @@ namespace HideAndSeek
             House.FileSystem = fileSystem.Object;
         }
         
-        public static IEnumerable TestCases_For_Test_GameController_CheckErrorMessage_ForHouseFileDoesNotExist
+        public static IEnumerable TestCases_For_Test_GameController_CheckErrorMessage_WhenHouseFileDoesNotExist
         {
             get
             {
@@ -330,8 +330,8 @@ namespace HideAndSeek
                     SetUpMockFileSystemForNonexistentHouseFile(); // Set up mock file system
                     new GameController("MyNonexistentFile"); // Call GameController constructor
                 })
-                    .SetName("Test_GameController_Constructor_AndCheckErrorMessage_ForHouseFileDoesNotExist - constructor")
-                    .SetCategory("GameController CustomHouse Constructor Failure");
+                    .SetName("Test_GameController_Constructor_AndCheckErrorMessage_WhenHouseFileDoesNotExist - constructor")
+                    .SetCategory("GameController CustomHouse Constructor FileNotFoundException Failure");
 
                 yield return new TestCaseData(() =>
                 {
@@ -339,8 +339,8 @@ namespace HideAndSeek
                     SetUpMockFileSystemForNonexistentHouseFile(); // Set up mock file system
                     gameController.RestartGame("MyNonexistentFile"); // Call RestartGame
                 })
-                    .SetName("Test_GameController_Constructor_AndCheckErrorMessage_ForHouseFileDoesNotExist - RestartGame")
-                    .SetCategory("GameController CustomHouse RestartGame Failure");
+                    .SetName("Test_GameController_Constructor_AndCheckErrorMessage_WhenHouseFileDoesNotExist - RestartGame")
+                    .SetCategory("GameController CustomHouse RestartGame FileNotFoundException Failure");
             }
         }
 
@@ -428,12 +428,12 @@ namespace HideAndSeek
                 // Set custom House using GameController constructor
                 yield return new TestCaseData(GetGameController_WithCustomHouseSetViaConstructor())
                     .SetName("Test_GameController_CustomHouse_FullGame_AndCheckMessageAndProperties - constructor")
-                    .SetCategory("GameController CustomHouse Constructor Move Check Message Prompt Status MoveNumber GameOver Success");
+                    .SetCategory("GameController CustomHouse Constructor Move Check Message Prompt Status MoveNumber GameOver InvalidOperationException Success");
 
                 // Set custom House using GameController RestartGame method
                 yield return new TestCaseData(GetGameController_WithCustomHouseSetViaRestartGame())
                     .SetName("Test_GameController_CustomHouse_FullGame_AndCheckMessageAndProperties - RestartGame")
-                    .SetCategory("GameController CustomHouse RestartGame Move Check Message Prompt Status MoveNumber GameOver Success");
+                    .SetCategory("GameController CustomHouse RestartGame Move Check Message Prompt Status MoveNumber GameOver InvalidOperationException Success");
             }
         }
     }

--- a/HideAndSeekTestProject/TestGameController_CustomOpponents.cs
+++ b/HideAndSeekTestProject/TestGameController_CustomOpponents.cs
@@ -58,8 +58,8 @@ namespace HideAndSeek
         [TestCase(0)]
         [TestCase(11)]
         [TestCase(500)]
-        [Category("GameController Constructor SpecifiedNumberOfOpponents OpponentsAndHidingPlaces Failure")]
-        public void Test_GameController_Constructor_WithInvalidNumberOfOpponents_AndCheckErrorMessage(int numberOfOpponents)
+        [Category("GameController Constructor SpecifiedNumberOfOpponents OpponentsAndHidingPlaces ArgumentException Failure")]
+        public void Test_GameController_Constructor_AndCheckErrorMessage_ForInvalidNumberOfOpponents(int numberOfOpponents)
         {
             Assert.Multiple(() =>
             {
@@ -68,7 +68,7 @@ namespace HideAndSeek
                     new GameController(numberOfOpponents, "DefaultHouse");
                 });
 
-                Assert.That(exception.Message, Is.EqualTo("Cannot create a new instance of GameController " +
+                Assert.That(exception.Message, Does.StartWith("Cannot create a new instance of GameController " +
                                                           "because the number of Opponents specified is invalid (must be between 1 and 10)"));
             });
         }
@@ -170,8 +170,8 @@ namespace HideAndSeek
         }
 
         [Test]
-        [Category("GameController Constructor SpecifiedNamesOfOpponents OpponentsAndHidingPlaces Failure")]
-        public void Test_GameController_Constructor_WithEmptyArrayOfNamesOfOpponents_AndCheckErrorMessage()
+        [Category("GameController Constructor SpecifiedNamesOfOpponents OpponentsAndHidingPlaces ArgumentException Failure")]
+        public void Test_GameController_Constructor_AndCheckErrorMessage_ForEmptyArrayOfNamesOfOpponents()
         {
             Assert.Multiple(() =>
             {
@@ -180,24 +180,23 @@ namespace HideAndSeek
                     new GameController(Array.Empty<string>(), "DefaultHouse");
                 });
 
-                Assert.That(exception.Message, Is.EqualTo("Cannot create a new instance of GameController because no names for Opponents were passed in"));
+                Assert.That(exception.Message, Does.StartWith("Cannot create a new instance of GameController because no names for Opponents were passed in"));
             });
         }
 
         [TestCase("")]
         [TestCase(" ")]
-        [Category("GameController Constructor SpecifiedNamesOfOpponents OpponentsAndHidingPlaces Failure")]
-        public void Test_GameController_Constructor_WithInvalidOpponentName_AndCheckErrorMessage(string invalidName)
+        [Category("GameController Constructor SpecifiedNamesOfOpponents OpponentsAndHidingPlaces ArgumentException Failure")]
+        public void Test_GameController_Constructor_AndCheckErrorMessage_ForInvalidOpponentName(string invalidName)
         {
             Assert.Multiple(() =>
             {
                 // Assert that calling constructor with array with invalid name of Opponent raises an exception
-                var exception = Assert.Throws<InvalidDataException>(() => {
+                var exception = Assert.Throws<ArgumentException>(() => {
                     new GameController(new string[] {invalidName}, "DefaultHouse");
                 });
 
-                Assert.That(exception.Message, Is.EqualTo($"Cannot perform action because opponent name \"{invalidName}\" is invalid " +
-                                                           "(is empty or contains only whitespace)"));
+                Assert.That(exception.Message, Does.StartWith($"opponent name \"{invalidName}\" is invalid (is empty or contains only whitespace)"));
             });
         }
     }

--- a/HideAndSeekTestProject/TestGameController_DeleteGame.cs
+++ b/HideAndSeekTestProject/TestGameController_DeleteGame.cs
@@ -37,12 +37,12 @@ namespace HideAndSeek
         }
 
         [Test]
-        [Category("GameController DeleteGame Failure")]
+        [Category("GameController DeleteGame ArgumentException Failure")]
         public void Test_GameController_DeleteGame_AndCheckErrorMessage_ForInvalidFileName(
             [Values("", " ", "my saved game", "my\\saved\\game", "my/saved/game", "my/saved\\ game")] string fileName)
         {
             gameController = new GameController("DefaultHouse");
-            exception = Assert.Throws<InvalidDataException>(() => gameController.DeleteGame(fileName));
+            exception = Assert.Throws<ArgumentException>(() => gameController.DeleteGame(fileName));
             Assert.That(exception.Message, Is.EqualTo($"Cannot perform action because file name \"{fileName}\" " +
                                             $"is invalid (is empty or contains illegal characters, e.g. \\, /, or whitespace)"));
         }

--- a/HideAndSeekTestProject/TestGameController_DeleteGame.cs
+++ b/HideAndSeekTestProject/TestGameController_DeleteGame.cs
@@ -45,10 +45,12 @@ namespace HideAndSeek
             exception = Assert.Throws<ArgumentException>(() => gameController.DeleteGame(fileName));
             Assert.That(exception.Message, Does.StartWith($"Cannot perform action because file name \"{fileName}\" " +
                                                        "is invalid (is empty or contains illegal characters, e.g. \\, /, or whitespace)"));
+            Assert.That(exception.Message, Does.StartWith($"Cannot perform action because file name \"{fileName}\" " +
+                                                           "is invalid (is empty or contains illegal characters, e.g. \\, /, or whitespace)"));
         }
 
         [Test]
-        [Category("GameController DeleteGame Failure")]
+        [Category("GameController DeleteGame FileNotFoundException Failure")]
         public void Test_GameController_DeleteGame_AndCheckErrorMessage_ForNonexistentFile()
         {
             // Set up mock for file system

--- a/HideAndSeekTestProject/TestGameController_DeleteGame.cs
+++ b/HideAndSeekTestProject/TestGameController_DeleteGame.cs
@@ -43,8 +43,8 @@ namespace HideAndSeek
         {
             gameController = new GameController("DefaultHouse");
             exception = Assert.Throws<ArgumentException>(() => gameController.DeleteGame(fileName));
-            Assert.That(exception.Message, Is.EqualTo($"Cannot perform action because file name \"{fileName}\" " +
-                                            $"is invalid (is empty or contains illegal characters, e.g. \\, /, or whitespace)"));
+            Assert.That(exception.Message, Does.StartWith($"Cannot perform action because file name \"{fileName}\" " +
+                                                       "is invalid (is empty or contains illegal characters, e.g. \\, /, or whitespace)"));
         }
 
         [Test]

--- a/HideAndSeekTestProject/TestGameController_LoadGame.cs
+++ b/HideAndSeekTestProject/TestGameController_LoadGame.cs
@@ -164,12 +164,12 @@ namespace HideAndSeek
         }
 
         [Test]
-        [Category("GameController LoadGame Failure")]
+        [Category("GameController LoadGame ArgumentException Failure")]
         public void Test_GameController_LoadGame_AndCheckErrorMessage_ForInvalidFileName(
             [Values("", " ", "my saved game", "my\\saved\\game", "my/saved/game", "my/saved\\ game")] string fileName)
         {
             gameController = new GameController("DefaultHouse");
-            exception = Assert.Throws<InvalidDataException>(() => gameController.LoadGame(fileName));
+            exception = Assert.Throws<ArgumentException>(() => gameController.LoadGame(fileName));
             Assert.That(exception.Message, Is.EqualTo($"Cannot perform action because file name \"{fileName}\" " +
                                             $"is invalid (is empty or contains illegal characters, e.g. \\, /, or whitespace)"));
         }
@@ -209,6 +209,28 @@ namespace HideAndSeek
 
             // Assert that error message is correct
             Assert.That(exception.Message, Is.EqualTo($"Cannot process because data is corrupt - {endOfExceptionMessage}"));
+        }
+
+        [Test]
+        [Category("GameController LoadGame ArgumentException Failure")]
+        public void Test_GameController_LoadGame_AndCheckErrorMessage_WhenSavedGameFileDataHasInvalidInvalidValue_ForHouseFileName()
+        {
+            // Assert that loading corrupt game raises exception
+            exception = Assert.Throws<ArgumentException>(() => {
+                GetExceptionWhenLoadGameWithCorruptSavedGameFile(
+                        "{" +
+                            "\"HouseFileName\":\"a8}{{ /@uaou12 \"" + "," +
+                            TestGameController_LoadGame_TestData.SavedGame_Serialized_PlayerLocation_NoOpponentsGame + "," +
+                            TestGameController_LoadGame_TestData.SavedGame_Serialized_MoveNumber_NoFoundOpponents + "," +
+                            TestGameController_LoadGame_TestData.SavedGame_Serialized_OpponentsAndHidingLocations + "," +
+                            TestGameController_LoadGame_TestData.SavedGame_Serialized_FoundOpponents_NoFoundOpponents +
+                        "}");
+            });
+
+            // Assert that error message is correct
+            Assert.That(exception.Message, Is.EqualTo("Cannot process because data is corrupt - " +
+                                                      "Cannot perform action because file name \"a8}{{ /@uaou12 \" is invalid " +
+                                                      "(is empty or contains illegal characters, e.g. \\, /, or whitespace)"));
         }
 
         [TestCaseSource(typeof(TestGameController_LoadGame_TestData),

--- a/HideAndSeekTestProject/TestGameController_LoadGame.cs
+++ b/HideAndSeekTestProject/TestGameController_LoadGame.cs
@@ -170,8 +170,8 @@ namespace HideAndSeek
         {
             gameController = new GameController("DefaultHouse");
             exception = Assert.Throws<ArgumentException>(() => gameController.LoadGame(fileName));
-            Assert.That(exception.Message, Is.EqualTo($"Cannot perform action because file name \"{fileName}\" " +
-                                            $"is invalid (is empty or contains illegal characters, e.g. \\, /, or whitespace)"));
+            Assert.That(exception.Message, Does.StartWith($"Cannot perform action because file name \"{fileName}\" " +
+                                                           "is invalid (is empty or contains illegal characters, e.g. \\, /, or whitespace)"));
         }
 
         [Test]
@@ -228,9 +228,9 @@ namespace HideAndSeek
             });
 
             // Assert that error message is correct
-            Assert.That(exception.Message, Is.EqualTo("Cannot process because data is corrupt - " +
-                                                      "Cannot perform action because file name \"a8}{{ /@uaou12 \" is invalid " +
-                                                      "(is empty or contains illegal characters, e.g. \\, /, or whitespace)"));
+            Assert.That(exception.Message, Does.StartWith("Cannot process because data is corrupt - " +
+                                                          "Cannot perform action because file name \"a8}{{ /@uaou12 \" is invalid " +
+                                                          "(is empty or contains illegal characters, e.g. \\, /, or whitespace)"));
         }
 
         [TestCaseSource(typeof(TestGameController_LoadGame_TestData),

--- a/HideAndSeekTestProject/TestGameController_LoadGame_HouseFailure.cs
+++ b/HideAndSeekTestProject/TestGameController_LoadGame_HouseFailure.cs
@@ -36,7 +36,7 @@ namespace HideAndSeek
         }
 
         [Test]
-        [Category("GameController LoadGame House Failure")]
+        [Category("GameController LoadGame House FileNotFoundException Failure")]
         public void Test_GameController_LoadGame_AndCheckErrorMessage_ForNonexistentHouseFile()
         {
             // Initialize variable to text in SavedGame file
@@ -70,7 +70,7 @@ namespace HideAndSeek
 
         [TestCaseSource(typeof(TestGameController_LoadGame_HouseFailure_TestData),
             nameof(TestGameController_LoadGame_HouseFailure_TestData.TestCases_For_Test_GameController_LoadGame_AndCheckErrorMessage_WhenHouseFileFormatIsInvalid))]
-        [Category("GameController LoadGame House Failure")]
+        [Category("GameController LoadGame House JsonException Failure")]
         public void Test_GameController_LoadGame_AndCheckErrorMessage_WhenHouseFileFormatIsInvalid(
             string exceptionMessageEnding, string fileText)
         {
@@ -82,19 +82,19 @@ namespace HideAndSeek
 
         [TestCaseSource(typeof(TestGameController_LoadGame_HouseFailure_TestData),
             nameof(TestGameController_LoadGame_HouseFailure_TestData.TestCases_For_Test_GameController_LoadGame_AndCheckErrorMessage_WhenHouseFileDataHasWhitespaceValue))]
-        [Category("GameController LoadGame House Failure")]
+        [Category("GameController LoadGame House ArgumentException Failure")]
         public void Test_GameController_LoadGame_AndCheckErrorMessage_WhenHouseFileDataHasWhitespaceValue(
             string exceptionMessageEnding, string fileText)
         {
-            exception = Assert.Throws<InvalidDataException>(() => GetExceptionWhenLoadGameWithCorruptHouseFile(fileText));
-            Assert.That(exception.Message, Is.EqualTo("Cannot process because data is corrupt - " +
+            exception = Assert.Throws<ArgumentException>(() => GetExceptionWhenLoadGameWithCorruptHouseFile(fileText));
+            Assert.That(exception.Message, Does.StartWith("Cannot process because data is corrupt - " +
                                                       "Cannot process because data in house layout file CorruptHouse is invalid - " +
                                                       exceptionMessageEnding));
         }
 
         [TestCaseSource(typeof(TestGameController_LoadGame_HouseFailure_TestData),
             nameof(TestGameController_LoadGame_HouseFailure_TestData.TestCases_For_Test_GameController_LoadGame_AndCheckErrorMessage_WhenHouseFileDataHasInvalidDirection))]
-        [Category("GameController LoadGame House Failure")]
+        [Category("GameController LoadGame House JsonException Failure")]
         public void Test_GameController_LoadGame_AndCheckErrorMessage_WhenHouseFileDataHasInvalidDirection(string fileText)
         {
             exception = Assert.Throws<JsonException>(() => GetExceptionWhenLoadGameWithCorruptHouseFile(fileText));
@@ -105,12 +105,12 @@ namespace HideAndSeek
 
         [TestCaseSource(typeof(TestGameController_LoadGame_HouseFailure_TestData),
             nameof(TestGameController_LoadGame_HouseFailure_TestData.TestCases_For_Test_GameController_LoadGame_AndCheckErrorMessage_WhenHouseFileDataHasInvalidValue))]
-        [Category("GameController LoadGame House Failure")]
+        [Category("GameController LoadGame House ArgumentException Failure")]
         public void Test_GameController_LoadGame_AndCheckErrorMessage_WhenHouseFileDataHasInvalidValue(
             string errorMessageEnding, string fileText)
         {
-            exception = Assert.Throws<InvalidDataException>(() => GetExceptionWhenLoadGameWithCorruptHouseFile(fileText));
-            Assert.That(exception.Message, Is.EqualTo("Cannot process because data is corrupt - " +
+            exception = Assert.Throws<ArgumentException>(() => GetExceptionWhenLoadGameWithCorruptHouseFile(fileText));
+            Assert.That(exception.Message, Does.StartWith("Cannot process because data is corrupt - " +
                                                       "Cannot process because data in house layout file CorruptHouse is invalid - " +
                                                       errorMessageEnding));
         }
@@ -119,12 +119,12 @@ namespace HideAndSeek
             nameof(TestGameController_LoadGame_HouseFailure_TestData.TestCases_For_Test_GameController_LoadGame_AndCheckErrorMessage_WhenHouseFileDataHasInvalidValue_NonexistentLocation))]
         [Category("GameController LoadGame House InvalidOperationException Failure")]
         public void Test_GameController_LoadGame_AndCheckErrorMessage_WhenHouseFileDataHasInvalidValue_NonexistentLocation(
-        string errorMessageEnding, string fileText)
+            string errorMessageEnding, string fileText)
         {
             exception = Assert.Throws<InvalidOperationException>(() => GetExceptionWhenLoadGameWithCorruptHouseFile(fileText));
             Assert.That(exception.Message, Does.StartWith("Cannot process because data is corrupt - " +
-                                                          "Cannot process because data in house layout file CorruptHouse is corrupt - " +
-                                                          errorMessageEnding));
+                                                      "Cannot process because data in house layout file CorruptHouse is corrupt - " +
+                                                      errorMessageEnding));
         }
 
         /// <summary>

--- a/HideAndSeekTestProject/TestGameController_LoadGame_HouseFailure.cs
+++ b/HideAndSeekTestProject/TestGameController_LoadGame_HouseFailure.cs
@@ -115,6 +115,18 @@ namespace HideAndSeek
                                                       errorMessageEnding));
         }
 
+        [TestCaseSource(typeof(TestGameController_LoadGame_HouseFailure_TestData),
+            nameof(TestGameController_LoadGame_HouseFailure_TestData.TestCases_For_Test_GameController_LoadGame_AndCheckErrorMessage_WhenHouseFileDataHasInvalidValue_NonexistentLocation))]
+        [Category("GameController LoadGame House InvalidOperationException Failure")]
+        public void Test_GameController_LoadGame_AndCheckErrorMessage_WhenHouseFileDataHasInvalidValue_NonexistentLocation(
+        string errorMessageEnding, string fileText)
+        {
+            exception = Assert.Throws<InvalidOperationException>(() => GetExceptionWhenLoadGameWithCorruptHouseFile(fileText));
+            Assert.That(exception.Message, Does.StartWith("Cannot process because data is corrupt - " +
+                                                          "Cannot process because data in house layout file CorruptHouse is corrupt - " +
+                                                          errorMessageEnding));
+        }
+
         /// <summary>
         /// Call LoadGame to load game from saved game file referencing corrupt House file
         /// Fails test if exception not thrown

--- a/HideAndSeekTestProject/TestGameController_LoadGame_HouseFailure_TestData.cs
+++ b/HideAndSeekTestProject/TestGameController_LoadGame_HouseFailure_TestData.cs
@@ -467,7 +467,7 @@ namespace HideAndSeek
             get
             {
                 // Invalid Name (whitespace)
-                yield return new TestCaseData("Cannot perform action because house name \" \" is invalid (is empty or contains only whitespace)",
+                yield return new TestCaseData("house name \" \" is invalid (is empty or contains only whitespace)",
                         "{" +
                            "\"Name\":\" \"" + "," +
                            DefaultHouse_Serialized_HouseFileName + "," +
@@ -478,7 +478,7 @@ namespace HideAndSeek
                    .SetName("Test_GameController_LoadGame_AndCheckErrorMessage_WhenHouseFileDataHasWhitespaceValue - invalid Name - whitespace");
 
                 // Invalid HouseFileName (whitespace)
-                yield return new TestCaseData("Cannot perform action because house file name \" \" is invalid (is empty or contains illegal characters, e.g. \\, /, or whitespace)",
+                yield return new TestCaseData("house file name \" \" is invalid (is empty or contains illegal characters, e.g. \\, /, or whitespace)",
                         "{" +
                            DefaultHouse_Serialized_Name + "," +
                            "\"HouseFileName\":\" \"" + "," +
@@ -489,7 +489,7 @@ namespace HideAndSeek
                    .SetName("Test_GameController_LoadGame_AndCheckErrorMessage_WhenHouseFileDataHasWhitespaceValue - invalid HouseFileName - whitespace");
 
                 // Invalid PlayerStartingPoint (whitespace)
-                yield return new TestCaseData("Cannot perform action because player starting point location name \" \" is invalid (is empty or contains only whitespace)",
+                yield return new TestCaseData("player starting point location name \" \" is invalid (is empty or contains only whitespace)",
                         "{" +
                            DefaultHouse_Serialized_Name + "," +
                            DefaultHouse_Serialized_HouseFileName + "," +
@@ -500,7 +500,7 @@ namespace HideAndSeek
                    .SetName("Test_GameController_LoadGame_AndCheckErrorMessage_WhenHouseFileDataHasWhitespaceValue - invalid PlayerStartingPoint - whitespace");
 
                 // Invalid LocationsWithoutHidingPlaces - Location name is invalid (whitespace)
-                yield return new TestCaseData("Cannot perform action because location name \" \" is invalid (is empty or contains only whitespace)",
+                yield return new TestCaseData("location name \" \" is invalid (is empty or contains only whitespace)",
                         "{" +
                            DefaultHouse_Serialized_Name + "," +
                            DefaultHouse_Serialized_HouseFileName + "," +
@@ -524,7 +524,7 @@ namespace HideAndSeek
                    .SetName("Test_GameController_LoadGame_AndCheckErrorMessage_WhenHouseFileDataHasWhitespaceValue - LocationsWithoutHidingPlaces - invalid Location Name - whitespace");
 
                 // Invalid LocationsWithHidingPlaces - LocationWithHidingPlace name in invalid (whitespace)
-                yield return new TestCaseData("Cannot perform action because location name \" \" is invalid (is empty or contains only whitespace)",
+                yield return new TestCaseData("location name \" \" is invalid (is empty or contains only whitespace)",
                         "{" +
                            DefaultHouse_Serialized_Name + "," +
                            DefaultHouse_Serialized_HouseFileName + "," +
@@ -545,7 +545,7 @@ namespace HideAndSeek
                    .SetName("Test_GameController_LoadGame_AndCheckErrorMessage_WhenHouseFileDataHasWhitespaceValue - LocationsWithHidingPlaces - invalid Location Name - whitespace");
 
                 // Invalid LocationsWithHidingPlaces - LocationWithHidingPlace description is invalid (whitespace)
-                yield return new TestCaseData("Cannot perform action because hiding place \" \" is invalid (is empty or contains only whitespace)",
+                yield return new TestCaseData("hiding place \" \" is invalid (is empty or contains only whitespace)",
                         "{" +
                            DefaultHouse_Serialized_Name + "," +
                            DefaultHouse_Serialized_HouseFileName + "," +
@@ -645,7 +645,7 @@ namespace HideAndSeek
             get
             {
                 // Invalid LocationsWithHidingPlaces - empty list
-                yield return new TestCaseData("Cannot perform action because locations with hiding places list is empty",
+                yield return new TestCaseData("locations with hiding places list is empty",
                         "{" +
                            DefaultHouse_Serialized_Name + "," +
                            DefaultHouse_Serialized_HouseFileName + "," +
@@ -674,7 +674,7 @@ namespace HideAndSeek
                    .SetName("Test_GameController_LoadGame_AndCheckErrorMessage_WhenHouseFileDataHasInvalidValue - invalid LocationsWithHidingPlaces - empty");
 
                 // Invalid LocationsWithoutHidingPlaces - Location has no exits
-                yield return new TestCaseData("Cannot perform action because location \"Hallway\" must be assigned at least one exit",
+                yield return new TestCaseData("location \"Hallway\" must be assigned at least one exit",
                         "{" +
                            DefaultHouse_Serialized_Name + "," +
                            DefaultHouse_Serialized_HouseFileName + "," +
@@ -714,7 +714,7 @@ namespace HideAndSeek
                    .SetName("Test_GameController_LoadGame_AndCheckErrorMessage_WhenHouseFileDataHasInvalidValue - invalid LocationsWithoutHidingPlaces - no exits");
 
                 // Invalid LocationsWithHidingPlaces - LocationWithHidingPlace has no exits
-                yield return new TestCaseData("Cannot perform action because location \"Attic\" must be assigned at least one exit",
+                yield return new TestCaseData("location \"Attic\" must be assigned at least one exit",
                         "{" +
                            DefaultHouse_Serialized_Name + "," +
                            DefaultHouse_Serialized_HouseFileName + "," +
@@ -732,7 +732,7 @@ namespace HideAndSeek
                            "]" +
                        "}")
                    .SetName("Test_GameController_LoadGame_AndCheckErrorMessage_WhenHouseFileDataHasInvalidValue - invalid LocationsWithHidingPlaces - no exits");
-                }
+            }
         }
 
         public static IEnumerable TestCases_For_Test_GameController_LoadGame_AndCheckErrorMessage_WhenHouseFileDataHasInvalidValue_NonexistentLocation
@@ -740,7 +740,7 @@ namespace HideAndSeek
             get
             {
                 // Invalid PlayerStartingPoint - not a Location
-                yield return new TestCaseData("location \"Dungeon\" does not exist in House",
+                yield return new TestCaseData("player starting point location \"Dungeon\" does not exist in House",
                         "{" +
                            DefaultHouse_Serialized_Name + "," +
                            DefaultHouse_Serialized_HouseFileName + "," +
@@ -751,7 +751,7 @@ namespace HideAndSeek
                    .SetName("Test_GameController_LoadGame_AndCheckErrorMessage_WhenHouseFileDataHasInvalidValue_NonexistentLocation - PlayerStartingPoint");
 
                 // Invalid LocationsWithoutHidingPlaces - Location has nonexistent exit
-                yield return new TestCaseData("location \"Dungeon\" does not exist in House",
+                yield return new TestCaseData("\"Hallway\" exit location \"Dungeon\" in direction \"Down\" does not exist",
                         "{" +
                            DefaultHouse_Serialized_Name + "," +
                            DefaultHouse_Serialized_HouseFileName + "," +
@@ -797,7 +797,7 @@ namespace HideAndSeek
                    .SetName("Test_GameController_LoadGame_AndCheckErrorMessage_WhenHouseFileDataHasInvalidValue_NonexistentLocation - LocationsWithoutHidingPlaces");
 
                 // Invalid LocationsWithHidingPlaces - LocationWithHidingPlace has nonexistent exit
-                yield return new TestCaseData("location \"Dungeon\" does not exist in House",
+                yield return new TestCaseData("\"Bathroom\" exit location \"Dungeon\" in direction \"Down\" does not exist",
                         "{" +
                            DefaultHouse_Serialized_Name + "," +
                            DefaultHouse_Serialized_HouseFileName + "," +

--- a/HideAndSeekTestProject/TestGameController_LoadGame_HouseFailure_TestData.cs
+++ b/HideAndSeekTestProject/TestGameController_LoadGame_HouseFailure_TestData.cs
@@ -644,17 +644,6 @@ namespace HideAndSeek
         {
             get
             {
-                // Invalid PlayerStartingPoint - not a Location
-                yield return new TestCaseData("Cannot perform action because player starting point location \"Dungeon\" is not a location in the house",
-                        "{" +
-                           DefaultHouse_Serialized_Name + "," +
-                           DefaultHouse_Serialized_HouseFileName + "," +
-                           "\"PlayerStartingPoint\":\"Dungeon\"" + "," +
-                           DefaultHouse_Serialized_LocationsWithoutHidingPlaces + "," +
-                           DefaultHouse_Serialized_LocationsWithHidingPlaces +
-                       "}")
-                   .SetName("Test_GameController_LoadGame_AndCheckErrorMessage_WhenHouseFileDataHasInvalidValue - invalid PlayerStartingPoint - nonexistent");
-
                 // Invalid LocationsWithHidingPlaces - empty list
                 yield return new TestCaseData("Cannot perform action because locations with hiding places list is empty",
                         "{" +
@@ -743,9 +732,26 @@ namespace HideAndSeek
                            "]" +
                        "}")
                    .SetName("Test_GameController_LoadGame_AndCheckErrorMessage_WhenHouseFileDataHasInvalidValue - invalid LocationsWithHidingPlaces - no exits");
+                }
+        }
+
+        public static IEnumerable TestCases_For_Test_GameController_LoadGame_AndCheckErrorMessage_WhenHouseFileDataHasInvalidValue_NonexistentLocation
+        {
+            get
+            {
+                // Invalid PlayerStartingPoint - not a Location
+                yield return new TestCaseData("location \"Dungeon\" does not exist in House",
+                        "{" +
+                           DefaultHouse_Serialized_Name + "," +
+                           DefaultHouse_Serialized_HouseFileName + "," +
+                           "\"PlayerStartingPoint\":\"Dungeon\"" + "," +
+                           DefaultHouse_Serialized_LocationsWithoutHidingPlaces + "," +
+                           DefaultHouse_Serialized_LocationsWithHidingPlaces +
+                       "}")
+                   .SetName("Test_GameController_LoadGame_AndCheckErrorMessage_WhenHouseFileDataHasInvalidValue_NonexistentLocation - PlayerStartingPoint");
 
                 // Invalid LocationsWithoutHidingPlaces - Location has nonexistent exit
-                yield return new TestCaseData("Cannot perform action because \"Hallway\" exit location \"Dungeon\" in direction \"Down\" does not exist",
+                yield return new TestCaseData("location \"Dungeon\" does not exist in House",
                         "{" +
                            DefaultHouse_Serialized_Name + "," +
                            DefaultHouse_Serialized_HouseFileName + "," +
@@ -788,10 +794,10 @@ namespace HideAndSeek
                            "]" + "," +
                            DefaultHouse_Serialized_LocationsWithHidingPlaces +
                        "}")
-                   .SetName("Test_GameController_LoadGame_AndCheckErrorMessage_WhenHouseFileDataHasInvalidValue - invalid LocationsWithoutHidingPlaces - nonexistent exit");
+                   .SetName("Test_GameController_LoadGame_AndCheckErrorMessage_WhenHouseFileDataHasInvalidValue_NonexistentLocation - LocationsWithoutHidingPlaces");
 
                 // Invalid LocationsWithHidingPlaces - LocationWithHidingPlace has nonexistent exit
-                yield return new TestCaseData("Cannot perform action because \"Bathroom\" exit location \"Dungeon\" in direction \"Down\" does not exist",
+                yield return new TestCaseData("location \"Dungeon\" does not exist in House",
                         "{" +
                            DefaultHouse_Serialized_Name + "," +
                            DefaultHouse_Serialized_HouseFileName + "," +
@@ -890,7 +896,7 @@ namespace HideAndSeek
                                 "}" +
                            "]" +
                        "}")
-                   .SetName("Test_GameController_LoadGame_AndCheckErrorMessage_WhenHouseFileDataHasInvalidValue - invalid LocationsWithHidingPlaces - nonexistent exit");
+                   .SetName("Test_GameController_LoadGame_AndCheckErrorMessage_WhenHouseFileDataHasInvalidValue_NonexistentLocation - LocationsWithHidingPlaces");
             }
         }
     }

--- a/HideAndSeekTestProject/TestGameController_LoadGame_TestData.cs
+++ b/HideAndSeekTestProject/TestGameController_LoadGame_TestData.cs
@@ -522,7 +522,7 @@ namespace HideAndSeek
             }
         }
 
-        public static IEnumerable TestCases_For_Test_GameController_LoadGame_AndCheckErrorMessage_WhenSavedGameFileFormatIsInvalid
+        public static IEnumerable TestCases_For_Test_GameController_LoadGame_AndCheckErrorMessage_WhenFileFormatIsInvalid
         {
             get
             {
@@ -530,17 +530,17 @@ namespace HideAndSeek
                 // No data in file
                 yield return new TestCaseData("The input does not contain any JSON tokens. Expected the input to start with a valid JSON token, when isFinalBlock is true. Path: $ | LineNumber: 0 | BytePositionInLine: 0.",
                         "")
-                    .SetName("Test_GameController_LoadGame_AndCheckErrorMessage_WhenSavedGameFileFormatIsInvalid - no data in file");
+                    .SetName("Test_GameController_LoadGame_AndCheckErrorMessage_WhenFileFormatIsInvalid - no data in file");
 
                 // Only whitespace in file
                 yield return new TestCaseData("The input does not contain any JSON tokens. Expected the input to start with a valid JSON token, when isFinalBlock is true. Path: $ | LineNumber: 0 | BytePositionInLine: 2.",
                         "  ")
-                    .SetName("Test_GameController_LoadGame_AndCheckErrorMessage_WhenSavedGameFileFormatIsInvalid - only whitespace in file");
+                    .SetName("Test_GameController_LoadGame_AndCheckErrorMessage_WhenFileFormatIsInvalid - only whitespace in file");
 
                 // Just characters in file (not JSON)
                 yield return new TestCaseData("'A' is an invalid start of a value. Path: $ | LineNumber: 0 | BytePositionInLine: 0.",
                         "ABCDeaoueou[{}}({}")
-                    .SetName("Test_GameController_LoadGame_AndCheckErrorMessage_WhenSavedGameFileFormatIsInvalid - just characters in file");
+                    .SetName("Test_GameController_LoadGame_AndCheckErrorMessage_WhenFileFormatIsInvalid - just characters in file");
 
                 // MISSING KEY/VALUE SET
                 // Missing House file name
@@ -551,7 +551,7 @@ namespace HideAndSeek
                             SavedGame_Serialized_OpponentsAndHidingLocations + "," +
                             SavedGame_Serialized_FoundOpponents_NoFoundOpponents +
                         "}")
-                    .SetName("Test_GameController_LoadGame_AndCheckErrorMessage_WhenSavedGameFileFormatIsInvalid - missing house file name");
+                    .SetName("Test_GameController_LoadGame_AndCheckErrorMessage_WhenFileFormatIsInvalid - missing house file name");
 
                 // Missing player location
                 yield return new TestCaseData("JSON deserialization for type 'HideAndSeek.SavedGame' was missing required properties, including the following: PlayerLocation",
@@ -561,7 +561,7 @@ namespace HideAndSeek
                             SavedGame_Serialized_OpponentsAndHidingLocations + "," +
                             SavedGame_Serialized_FoundOpponents_NoFoundOpponents +
                         "}")
-                    .SetName("Test_GameController_LoadGame_AndCheckErrorMessage_WhenSavedGameFileFormatIsInvalid - missing player location");
+                    .SetName("Test_GameController_LoadGame_AndCheckErrorMessage_WhenFileFormatIsInvalid - missing player location");
 
                 // Missing move number
                 yield return new TestCaseData("JSON deserialization for type 'HideAndSeek.SavedGame' was missing required properties, including the following: MoveNumber",
@@ -571,7 +571,7 @@ namespace HideAndSeek
                             SavedGame_Serialized_OpponentsAndHidingLocations + "," +
                             SavedGame_Serialized_FoundOpponents_NoFoundOpponents +
                         "}")
-                    .SetName("Test_GameController_LoadGame_AndCheckErrorMessage_WhenSavedGameFileFormatIsInvalid - missing move number");
+                    .SetName("Test_GameController_LoadGame_AndCheckErrorMessage_WhenFileFormatIsInvalid - missing move number");
 
                 // Missing opponents and hiding locations
                 yield return new TestCaseData("JSON deserialization for type 'HideAndSeek.SavedGame' was missing required properties, including the following: OpponentsAndHidingLocations",
@@ -581,7 +581,7 @@ namespace HideAndSeek
                             SavedGame_Serialized_MoveNumber_NoFoundOpponents + "," +
                             SavedGame_Serialized_FoundOpponents_NoFoundOpponents +
                         "}")
-                    .SetName("Test_GameController_LoadGame_AndCheckErrorMessage_WhenSavedGameFileFormatIsInvalid - missing opponents and hiding locations");
+                    .SetName("Test_GameController_LoadGame_AndCheckErrorMessage_WhenFileFormatIsInvalid - missing opponents and hiding locations");
 
                 // Missing found opponents
                 yield return new TestCaseData("JSON deserialization for type 'HideAndSeek.SavedGame' was missing required properties, including the following: FoundOpponents",
@@ -591,17 +591,17 @@ namespace HideAndSeek
                             SavedGame_Serialized_MoveNumber_NoFoundOpponents + "," +
                             SavedGame_Serialized_OpponentsAndHidingLocations +
                         "}")
-                    .SetName("Test_GameController_LoadGame_AndCheckErrorMessage_WhenSavedGameFileFormatIsInvalid - missing found opponents");
+                    .SetName("Test_GameController_LoadGame_AndCheckErrorMessage_WhenFileFormatIsInvalid - missing found opponents");
             }
         }
 
-        public static IEnumerable TestCases_For_Test_GameController_LoadGame_AndCheckErrorMessage_WhenSavedGameFileDataHasInvalidValue
+        public static IEnumerable TestCases_For_Test_GameController_LoadGame_AndCheckErrorMessage_WhenFileDataHasInvalidValue
         {
             get
             {
                 // INVALID VALUE DATA
                 // Invalid player location
-                yield return new TestCaseData("invalid PlayerLocation",
+                yield return new TestCaseData("invalid PlayerLocation - location \"Tree\" does not exist in House",
                         "{" +
                             SavedGame_Serialized_HouseFileName + "," +
                             "\"PlayerLocation\":\"Tree\"," +
@@ -609,32 +609,10 @@ namespace HideAndSeek
                             SavedGame_Serialized_OpponentsAndHidingLocations + "," +
                             SavedGame_Serialized_FoundOpponents_NoFoundOpponents +
                         "}")
-                    .SetName("Test_GameController_LoadGame_AndCheckErrorMessage_WhenSavedGameFileDataHasInvalidValue - invalid PlayerLocation");
-
-                // Invalid (negative) move number
-                yield return new TestCaseData("invalid MoveNumber",
-                        "{" +
-                            SavedGame_Serialized_HouseFileName + "," +
-                            SavedGame_Serialized_PlayerLocation_NoOpponentsGame + "," +
-                            "\"MoveNumber\":-1" + "," +
-                            SavedGame_Serialized_OpponentsAndHidingLocations + "," +
-                            SavedGame_Serialized_FoundOpponents_NoFoundOpponents +
-                        "}")
-                    .SetName("Test_GameController_LoadGame_AndCheckErrorMessage_WhenSavedGameFileDataHasInvalidValue - invalid MoveNumber");
-
-                // No opponents
-                yield return new TestCaseData("no opponents",
-                        "{" +
-                            SavedGame_Serialized_HouseFileName + "," +
-                            SavedGame_Serialized_PlayerLocation_NoOpponentsGame + "," +
-                            SavedGame_Serialized_MoveNumber_NoFoundOpponents + "," +
-                            "\"OpponentsAndHidingLocations\":{}" + "," +
-                            SavedGame_Serialized_FoundOpponents_NoFoundOpponents +
-                        "}")
-                    .SetName("Test_GameController_LoadGame_AndCheckErrorMessage_WhenSavedGameFileDataHasInvalidValue - no opponents");
+                    .SetName("Test_GameController_LoadGame_AndCheckErrorMessage_WhenFileDataHasInvalidValue - invalid PlayerLocation");
 
                 // Invalid hiding place for Joe (not yet found) because location does not exist
-                yield return new TestCaseData("invalid hiding location for opponent",
+                yield return new TestCaseData("location with hiding place \"Tree\" does not exist in House",
                         "{" +
                             SavedGame_Serialized_HouseFileName + "," +
                             SavedGame_Serialized_PlayerLocation_NoOpponentsGame + "," +
@@ -649,10 +627,10 @@ namespace HideAndSeek
                             "}" + "," +
                             SavedGame_Serialized_FoundOpponents_NoFoundOpponents +
                         "}")
-                    .SetName("Test_GameController_LoadGame_AndCheckErrorMessage_WhenSavedGameFileDataHasInvalidValue - invalid hiding place for opponent - Location does not exist");
+                    .SetName("Test_GameController_LoadGame_AndCheckErrorMessage_WhenFileDataHasInvalidValue - invalid hiding place for opponent - Location does not exist");
 
                 // Invalid hiding place for Joe (not yet found) because hiding location is not of type LocationWithHidingPlace
-                yield return new TestCaseData("invalid hiding location for opponent",
+                yield return new TestCaseData("location with hiding place \"Hallway\" does not exist in House",
                         "{" +
                             SavedGame_Serialized_HouseFileName + "," +
                             SavedGame_Serialized_PlayerLocation_NoOpponentsGame + "," +
@@ -667,7 +645,7 @@ namespace HideAndSeek
                             "}" + "," +
                             SavedGame_Serialized_FoundOpponents_NoFoundOpponents +
                         "}")
-                    .SetName("Test_GameController_LoadGame_AndCheckErrorMessage_WhenSavedGameFileDataHasInvalidValue - invalid hiding place for opponent - not LocationWithHidingPlace");
+                    .SetName("Test_GameController_LoadGame_AndCheckErrorMessage_WhenFileDataHasInvalidValue - invalid hiding place for opponent - not LocationWithHidingPlace");
 
                 // Found opponent is not in all opponents list
                 yield return new TestCaseData("found opponent is not an opponent",
@@ -678,7 +656,7 @@ namespace HideAndSeek
                             SavedGame_Serialized_OpponentsAndHidingLocations + "," +
                             "\"FoundOpponents\":[\"Steve\"]" +
                         "}")
-                    .SetName("Test_GameController_LoadGame_AndCheckErrorMessage_WhenSavedGameFileDataHasInvalidValue - found opponent Steve is not opponent");
+                    .SetName("Test_GameController_LoadGame_AndCheckErrorMessage_WhenFileDataHasInvalidValue - found opponent Steve is not opponent");
             }
         }
 

--- a/HideAndSeekTestProject/TestGameController_LoadGame_TestData.cs
+++ b/HideAndSeekTestProject/TestGameController_LoadGame_TestData.cs
@@ -600,17 +600,6 @@ namespace HideAndSeek
             get
             {
                 // INVALID VALUE DATA
-                // Invalid House file name
-                yield return new TestCaseData("Cannot perform action because file name \"a8}{{ /@uaou12 \" is invalid (is empty or contains illegal characters, e.g. \\, /, or whitespace)",
-                        "{" +
-                            "\"HouseFileName\":\"a8}{{ /@uaou12 \"" + "," +
-                            SavedGame_Serialized_PlayerLocation_NoOpponentsGame + "," +
-                            SavedGame_Serialized_MoveNumber_NoFoundOpponents + "," +
-                            SavedGame_Serialized_OpponentsAndHidingLocations + "," +
-                            SavedGame_Serialized_FoundOpponents_NoFoundOpponents +
-                        "}")
-                    .SetName("Test_GameController_LoadGame_AndCheckErrorMessage_WhenSavedGameFileDataHasInvalidValue - invalid HouseFileName");
-
                 // Invalid player location
                 yield return new TestCaseData("invalid PlayerLocation",
                         "{" +

--- a/HideAndSeekTestProject/TestGameController_MoveAndTeleport.cs
+++ b/HideAndSeekTestProject/TestGameController_MoveAndTeleport.cs
@@ -215,8 +215,8 @@ namespace HideAndSeek
         [TestCase("}{yaeu\\@!//")]
         [TestCase("No")]
         [TestCase("Northuperly")]
-        [Category("GameController Move CurrentLocation MoveNumber Failure")]
-        public void Test_GameController_Move_InInvalidDirection_AndCheckErrorMessageAndProperties(string directionText)
+        [Category("GameController Move CurrentLocation MoveNumber ArgumentException Failure")]
+        public void Test_GameController_Move_AndCheckErrorMessageAndProperties_ForInvalidDirection(string directionText)
         {
             Location initialLocation = gameController.CurrentLocation; // Get initial location before attempt to move
 
@@ -235,7 +235,7 @@ namespace HideAndSeek
         [TestCaseSource(typeof(TestGameController_MoveAndTeleport_TestData), 
             nameof(TestGameController_MoveAndTeleport_TestData.TestCases_For_Test_GameController_Move_InDirectionWithNoLocation_AndCheckErrorMessageAndProperties))]
         [Category("GameController Move CurrentLocation MoveNumber Failure")]
-        public void Test_GameController_Move_InDirectionWithNoLocation_AndCheckErrorMessageAndProperties(
+        public void Test_GameController_Move_AndCheckErrorMessageAndProperties_ForDirectionWithNoLocation(
             Func<GameController, Exception> Move)
         {
             Location initialLocation = gameController.CurrentLocation; // Get initial location before attempt to move

--- a/HideAndSeekTestProject/TestGameController_MoveAndTeleport.cs
+++ b/HideAndSeekTestProject/TestGameController_MoveAndTeleport.cs
@@ -225,7 +225,7 @@ namespace HideAndSeek
                 Exception exception = Assert.Throws<ArgumentException>(() => {
                     gameController.Move(directionText);
                 });
-                Assert.That(exception.Message, Is.EqualTo("That's not a valid direction"), "exception message");
+                Assert.That(exception.Message, Does.StartWith("That's not a valid direction"), "exception message");
                 Assert.That(gameController.CurrentLocation, Is.EqualTo(initialLocation), "current location does not change");
                 Assert.That(gameController.MoveNumber, Is.EqualTo(1), "move number does not increment");
                 Assert.That(gameController.GameOver, Is.False, "game not over after trying to move");

--- a/HideAndSeekTestProject/TestGameController_RestartRehide.cs
+++ b/HideAndSeekTestProject/TestGameController_RestartRehide.cs
@@ -86,13 +86,13 @@ namespace HideAndSeek
             Assert.Multiple(() =>
             {
                 // Assert that hiding an Opponent in a location with an invalid name raises an exception
-                var exception = Assert.Throws<NullReferenceException>(() =>
+                var exception = Assert.Throws<InvalidOperationException>(() =>
                 {
                     gameController.RehideAllOpponents(new List<string>() { "Dungeon", "Lavatory", "Eggshells", "Worm Hole", "Zoo" });
                 });
 
                 // Assert that exception message is as expected
-                Assert.That(exception.Message, Is.EqualTo("Object reference not set to an instance of an object."));
+                Assert.That(exception.Message, Is.EqualTo("location with hiding place \"Dungeon\" does not exist in House"));
             });
         }
 

--- a/HideAndSeekTestProject/TestGameController_RestartRehide.cs
+++ b/HideAndSeekTestProject/TestGameController_RestartRehide.cs
@@ -80,7 +80,7 @@ namespace HideAndSeek
         }
 
         [Test]
-        [Category("GameController RehideAllOpponents Failure")]
+        [Category("GameController RehideAllOpponents InvalidOperationException Failure")]
         public void Test_GameController_RehideAllOpponents_InSpecificPlaces_AndCheckErrorMessage_ForNonexistentLocation()
         {
             Assert.Multiple(() =>
@@ -102,7 +102,7 @@ namespace HideAndSeek
         [TestCase("Living Room", "Kitchen", "Pantry")]
         [TestCase("Living Room", "Kitchen", "Pantry", "Attic")]
         [TestCase("Living Room", "Kitchen", "Pantry", "Attic", "Master Bedroom", "Kids Room")]
-        [Category("GameController RehideAllOpponents Failure")]
+        [Category("GameController RehideAllOpponents ArgumentOutOfRangeException Failure")]
         public void Test_GameController_RehideAllOpponents_InSpecificPlaces_AndCheckErrorMessage_ForIncorrectNumberOfHidingPlaces(params string[] hidingPlaces)
         {
             Assert.Multiple(() =>

--- a/HideAndSeekTestProject/TestGameController_SaveGame.cs
+++ b/HideAndSeekTestProject/TestGameController_SaveGame.cs
@@ -96,7 +96,7 @@ namespace HideAndSeek
         }
 
         [Test]
-        [Category("GameController SaveGame Failure")]
+        [Category("GameController SaveGame InvalidOperationException Failure")]
         public void Test_GameController_SaveGame_AndCheckErrorMessage_ForAlreadyExistingFile()
         {
             // Set up mock for GameController file system

--- a/HideAndSeekTestProject/TestGameController_SaveGame.cs
+++ b/HideAndSeekTestProject/TestGameController_SaveGame.cs
@@ -91,8 +91,8 @@ namespace HideAndSeek
         {
             gameController = new GameController("DefaultHouse");
             exception = Assert.Throws<ArgumentException>(() => gameController.SaveGame(fileName));
-            Assert.That(exception.Message, Is.EqualTo($"Cannot perform action because file name \"{fileName}\" " +
-                                            $"is invalid (is empty or contains illegal characters, e.g. \\, /, or whitespace)"));
+            Assert.That(exception.Message, Does.StartWith($"Cannot perform action because file name \"{fileName}\" " +
+                                                           "is invalid (is empty or contains illegal characters, e.g. \\, /, or whitespace)"));
         }
 
         [Test]

--- a/HideAndSeekTestProject/TestGameController_SaveGame.cs
+++ b/HideAndSeekTestProject/TestGameController_SaveGame.cs
@@ -85,12 +85,12 @@ namespace HideAndSeek
         }
 
         [Test]
-        [Category("GameController SaveGame Failure")]
+        [Category("GameController SaveGame ArgumentException Failure")]
         public void Test_GameController_SaveGame_AndCheckErrorMessage_ForInvalidFileName(
             [Values("", " ", "my saved game", "my\\saved\\game", "my/saved/game", "my/saved\\ game")] string fileName)
         {
             gameController = new GameController("DefaultHouse");
-            exception = Assert.Throws<InvalidDataException>(() => gameController.SaveGame(fileName));
+            exception = Assert.Throws<ArgumentException>(() => gameController.SaveGame(fileName));
             Assert.That(exception.Message, Is.EqualTo($"Cannot perform action because file name \"{fileName}\" " +
                                             $"is invalid (is empty or contains illegal characters, e.g. \\, /, or whitespace)"));
         }

--- a/HideAndSeekTestProject/TestHouse.cs
+++ b/HideAndSeekTestProject/TestHouse.cs
@@ -460,7 +460,7 @@ namespace HideAndSeek
         }
 
         [Test]
-        [Category("House CreateHouse Failure")]
+        [Category("House CreateHouse FileNotFoundException Failure")]
         public void Test_House_CreateHouse_AndCheckErrorMessage_WhenFileDoesNotExist()
         {
             // Set up mock file system and assign to House property
@@ -482,9 +482,9 @@ namespace HideAndSeek
         }
 
         [TestCaseSource(typeof(TestHouse_TestData), 
-            nameof(TestHouse_TestData.TestCases_For_Test_House_CreateHouse_AndCheckErrorMessage_ForJsonException_WhenFileFormatIsInvalid))]
-        [Category("House CreateHouse Failure")]
-        public void Test_House_CreateHouse_AndCheckErrorMessage_ForJsonException_WhenFileFormatIsInvalid(
+            nameof(TestHouse_TestData.TestCases_For_Test_House_CreateHouse_AndCheckErrorMessage_WhenFileFormatIsInvalid))]
+        [Category("House CreateHouse JsonException Failure")]
+        public void Test_House_CreateHouse_AndCheckErrorMessage_WhenFileFormatIsInvalid(
             string exceptionMessageEnding, string fileText)
         {
             // Assign mock file system to House property
@@ -504,9 +504,9 @@ namespace HideAndSeek
         }
 
         [TestCaseSource(typeof(TestHouse_TestData), 
-            nameof(TestHouse_TestData.TestCases_For_Test_House_CreateHouse_AndCheckErrorMessage_ForJsonException_WhenFileDataHasInvalidDirection))]
-        [Category("House CreateHouse Failure")]
-        public void Test_House_CreateHouse_AndCheckErrorMessage_ForJsonException_WhenFileDataHasInvalidDirection(string fileText)
+            nameof(TestHouse_TestData.TestCases_For_Test_House_CreateHouse_AndCheckErrorMessage_WhenFileDataHasInvalidDirection))]
+        [Category("House CreateHouse JsonException Failure")]
+        public void Test_House_CreateHouse_AndCheckErrorMessage_WhenFileDataHasInvalidDirection(string fileText)
         {
             // Assign mock file system to House property
             House.FileSystem = MockFileSystemHelper.GetMockedFileSystem_ToReadAllText("MyCorruptFile.json", fileText);
@@ -526,9 +526,9 @@ namespace HideAndSeek
         }
 
         [TestCaseSource(typeof(TestHouse_TestData), 
-            nameof(TestHouse_TestData.TestCases_For_Test_House_CreateHouse_AndCheckErrorMessage_ForInvalidDataException_WhenFileDataHasWhitespaceValue))]
-        [Category("House CreateHouse Failure")]
-        public void Test_House_CreateHouse_AndCheckErrorMessage_ForInvalidDataException_WhenFileDataHasWhitespaceValue(
+            nameof(TestHouse_TestData.TestCases_For_Test_House_CreateHouse_AndCheckErrorMessage_WhenFileDataHasWhitespaceValue))]
+        [Category("House CreateHouse ArgumentException Failure")]
+        public void Test_House_CreateHouse_AndCheckErrorMessage_WhenFileDataHasWhitespaceValue(
             string exceptionMessageEnding, string fileText)
         {
             // Assign mock file system to House property
@@ -537,20 +537,20 @@ namespace HideAndSeek
             Assert.Multiple(() =>
             {
                 // Assert that creating a SavedGame object with a file with a whitespace value for a property throws an exception
-                var exception = Assert.Throws<InvalidDataException>(() =>
+                var exception = Assert.Throws<ArgumentException>(() =>
                 {
                     House.CreateHouse("MyInvalidDataFile");
                 });
                 
                 // Assert that exception message is as expected
-                Assert.That(exception.Message, Is.EqualTo($"Cannot process because data in house layout file MyInvalidDataFile is invalid - {exceptionMessageEnding}"));
+                Assert.That(exception.Message, Does.StartWith($"Cannot process because data in house layout file MyInvalidDataFile is invalid - {exceptionMessageEnding}"));
             });
         }
 
         [TestCaseSource(typeof(TestHouse_TestData), 
-            nameof(TestHouse_TestData.TestCases_For_Test_House_CreateHouse_AndCheckErrorMessage_ForInvalidDataException_WhenFileDataHasInvalidValue))]
-        [Category("House CreateHouse Failure")]
-        public void Test_House_CreateHouse_AndCheckErrorMessage_ForInvalidDataException_WhenFileDataHasInvalidValue(
+            nameof(TestHouse_TestData.TestCases_For_Test_House_CreateHouse_AndCheckErrorMessage_WhenFileDataHasInvalidValue))]
+        [Category("House CreateHouse ArgumentException Failure")]
+        public void Test_House_CreateHouse_AndCheckErrorMessage_WhenFileDataHasInvalidValue(
             string exceptionMessageEnding, string fileText)
         {
             // Assign mock file system to House property
@@ -559,20 +559,20 @@ namespace HideAndSeek
             Assert.Multiple(() =>
             {
                 // Assert that creating a SavedGame object with a file with an invalid value for a property throws an exception
-                var exception = Assert.Throws<InvalidDataException>(() =>
+                var exception = Assert.Throws<ArgumentException>(() =>
                 {
                     House.CreateHouse("MyInvalidDataFile");
                 });
 
                 // Assert that exception message is as expected
-                Assert.That(exception.Message, Is.EqualTo($"Cannot process because data in house layout file MyInvalidDataFile is invalid - {exceptionMessageEnding}"));
+                Assert.That(exception.Message, Does.StartWith($"Cannot process because data in house layout file MyInvalidDataFile is invalid - {exceptionMessageEnding}"));
             });
         }
 
         [TestCaseSource(typeof(TestHouse_TestData),
-            nameof(TestHouse_TestData.TestCases_For_Test_House_CreateHouse_AndCheckErrorMessage_ForInvalidDataException_WhenFileDataHasInvalidValue_NonexistentLocation))]
+            nameof(TestHouse_TestData.TestCases_For_Test_House_CreateHouse_AndCheckErrorMessage_WhenFileDataHasInvalidValue_NonexistentLocation))]
         [Category("House CreateHouse InvalidOperationException Failure")]
-        public void Test_House_CreateHouse_AndCheckErrorMessage_ForInvalidDataException_WhenFileDataHasInvalidValue_NonexistentLocation(
+        public void Test_House_CreateHouse_AndCheckErrorMessage_WhenFileDataHasInvalidValue_NonexistentLocation(
             string exceptionMessageEnding, string fileText)
         {
             // Assign mock file system to House property
@@ -612,20 +612,19 @@ namespace HideAndSeek
         
         [TestCase("")]
         [TestCase(" ")]
-        [Category("House Name Failure")]
+        [Category("House Name ArgumentException Failure")]
         public void Test_House_Set_Name_AndCheckErrorMessage_ForInvalidName(string name)
         {
             Assert.Multiple(() =>
             {
                 // Assert that setting House name to an invalid name raises an exception
-                var exception = Assert.Throws<InvalidDataException>(() =>
+                var exception = Assert.Throws<ArgumentException>(() =>
                 {
                     house.Name = name;
                 });
 
                 // Assert that exception message is as expected
-                Assert.That(exception.Message, Is.EqualTo($"Cannot perform action because house name \"{name}\" " +
-                                                          $"is invalid (is empty or contains only whitespace)"));
+                Assert.That(exception.Message, Does.StartWith($"house name \"{name}\" is invalid (is empty or contains only whitespace)"));
             });
         }
 
@@ -642,91 +641,88 @@ namespace HideAndSeek
         [TestCase("/myFile")]
         [TestCase("myFile/")]
         [TestCase("my/File")]
-        [Category("House HouseFileName Failure")]
-        public void Test_House_Set_HouseFileName_AndCheckErrorMessage_ForInvalidHouseFileName(string houseFileName)
+        [Category("House HouseFileName ArgumentException Failure")]
+        public void Test_House_Set_HouseFileName_AndCheckErrorMessage_ForInvalidFileName(string houseFileName)
         {
             Assert.Multiple(() =>
             {
                 // Assert that setting House file name to an invalid file name raises an exception
-                var exception = Assert.Throws<InvalidDataException>(() =>
+                var exception = Assert.Throws<ArgumentException>(() =>
                 {
                     house.HouseFileName = houseFileName;
                 });
 
                 // Assert that exception message is as expected
-                Assert.That(exception.Message, Is.EqualTo($"Cannot perform action because house file name \"{houseFileName}\" " +
-                                                          $"is invalid (is empty or contains illegal characters, e.g. \\, /, or whitespace)"));
+                Assert.That(exception.Message, Does.StartWith($"house file name \"{houseFileName}\" is invalid (is empty or contains illegal characters, e.g. \\, /, or whitespace)"));
             });
         }
 
         [TestCase("")]
         [TestCase(" ")]
-        [Category("House PlayerStartingPoint Failure")]
+        [Category("House PlayerStartingPoint ArgumentException Failure")]
         public void Test_House_Set_PlayerStartingPoint_AndCheckErrorMessage_ForInvalidLocationName(string locationName)
         {
             Assert.Multiple(() =>
             {
                 // Assert that setting player starting point location name to an invalid location name raises an exception
-                var exception = Assert.Throws<InvalidDataException>(() =>
+                var exception = Assert.Throws<ArgumentException>(() =>
                 {
                     house.PlayerStartingPoint = locationName;
                 });
 
                 // Assert that exception message is as expected
-                Assert.That(exception.Message, Is.EqualTo($"Cannot perform action because player starting point location name \"{locationName}\" " +
-                                                          $"is invalid (is empty or contains only whitespace)"));
+                Assert.That(exception.Message, Does.StartWith($"player starting point location name \"{locationName}\" is invalid (is empty or contains only whitespace)"));
             });
         }
 
         [Test]
-        [Category("House StartingPoint Failure")]
+        [Category("House StartingPoint InvalidOperationException Failure")]
         public void Test_House_Set_StartingPoint_AndCheckErrorMessage_ForLocationNotExistingInHouse()
         {
             Assert.Multiple(() =>
             {
                 // Assert that setting starting point location to a Location not in the House raises an exception
-                var exception = Assert.Throws<InvalidDataException>(() =>
+                var exception = Assert.Throws<InvalidOperationException>(() =>
                 {
                     house.StartingPoint = new Location("not in house");
                 });
 
                 // Assert that exception message is as expected
-                Assert.That(exception.Message, Is.EqualTo("Cannot perform action because player starting point location \"not in house\" " +
-                                                          "is not a location in the house"));
+                Assert.That(exception.Message, Is.EqualTo("player starting point location \"not in house\" does not exist in House"));
             });  
         }
 
         [Test]
-        [Category("House LocationsWithHidingPlaces Failure")]
+        [Category("House LocationsWithHidingPlaces ArgumentException Failure")]
         public void Test_House_Set_LocationsWithHidingPlaces_AndCheckErrorMessage_ForEmptyEnumerable()
         {
             Assert.Multiple(() =>
             {
                 // Assert that setting locations with hiding places property to an empty list raises an exception
-                var exception = Assert.Throws<InvalidDataException>(() =>
+                var exception = Assert.Throws<ArgumentException>(() =>
                 {
                     house.LocationsWithHidingPlaces = new List<LocationWithHidingPlace>();
                 });
 
                 // Assert that exception message is as expected
-                Assert.That(exception.Message, Is.EqualTo("Cannot perform action because locations with hiding places list is empty"));
+                Assert.That(exception.Message, Does.StartWith("locations with hiding places list is empty"));
             });
         }
 
         [Test]
-        [Category("House Locations Failure")]
+        [Category("House Locations ArgumentException Failure")]
         public void Test_House_Set_Locations_AndCheckErrorMessage_ForEmptyEnumerable()
         {
             Assert.Multiple(() =>
             {
                 // Assert that setting the locations property to an empty list raises an exception
-                var exception = Assert.Throws<InvalidDataException>(() =>
+                var exception = Assert.Throws<ArgumentException>(() =>
                 {
                     house.Locations = new List<Location>();
                 });
 
                 // Assert that exception message is as expected
-                Assert.That(exception.Message, Is.EqualTo("Cannot perform action because locations list is empty"));
+                Assert.That(exception.Message, Does.StartWith("locations list is empty"));
             });
         }
 

--- a/HideAndSeekTestProject/TestHouse.cs
+++ b/HideAndSeekTestProject/TestHouse.cs
@@ -156,10 +156,14 @@ namespace HideAndSeek
         [TestCase("MasterBedroom")]
         [TestCase(" ")]
         [TestCase("")]
-        [Category("House GetLocationByName Failure")]
-        public void Test_House_GetLocationByName_ReturnsNull_WhenLocationWithName_DoesNotExist(string locationName)
+        [Category("House GetLocationByName InvalidOperationException Failure")]
+        public void Test_House_GetLocationByName_AndCheckErrorMessage_WhenLocationWithName_DoesNotExist(string locationName)
         {
-            Assert.That(house.GetLocationByName(locationName), Is.Null);
+            Assert.Multiple(() =>
+            {
+                Exception exception = Assert.Throws<InvalidOperationException>(() => house.GetLocationByName(locationName));
+                Assert.That(exception.Message, Is.EqualTo("location \"" + locationName + "\" does not exist in House"));
+            });
         }
 
         [Test]
@@ -172,10 +176,14 @@ namespace HideAndSeek
         [TestCase("Entry")]
         [TestCase("Hallway")]
         [TestCase("Landing")]
-        [Category("House GetLocationWithHidingPlaceByName Failure")]
-        public void Test_House_GetLocationWithHidingPlaceByName_ReturnsNull_WhenLocationWithName_IsLocationWithoutHidingPlace(string locationName)
+        [Category("House GetLocationWithHidingPlaceByName InvalidOperationException Failure")]
+        public void Test_House_GetLocationWithHidingPlaceByName_AndCheckErrorMessage_WhenLocationDoesNotHaveHidingPlace(string locationName)
         {
-            Assert.That(house.GetLocationWithHidingPlaceByName(locationName), Is.Null);
+            Assert.Multiple(() =>
+            {
+                Exception exception = Assert.Throws<InvalidOperationException>(() => house.GetLocationWithHidingPlaceByName(locationName));
+                Assert.That(exception.Message, Is.EqualTo($"location with hiding place \"{locationName}\" does not exist in House"));
+            });
         }
 
         [TestCase("Secret Library")]
@@ -183,10 +191,14 @@ namespace HideAndSeek
         [TestCase("MasterBedroom")]
         [TestCase(" ")]
         [TestCase("")]
-        [Category("House GetLocationWithHidingPlaceByName Failure")]
-        public void Test_House_GetLocationWithHidingPlaceByName_ReturnsNull_WhenLocationWithName_DoesNotExist(string locationName)
+        [Category("House GetLocationWithHidingPlaceByName InvalidOperationException Failure")]
+        public void Test_House_GetLocationWithHidingPlaceByName_AndCheckErrorMessage_WhenNoLocationWithNameExistsInHouse(string locationName)
         {
-            Assert.That(house.GetLocationWithHidingPlaceByName(locationName), Is.Null);
+            Assert.Multiple(() =>
+            {
+                Exception exception = Assert.Throws<InvalidOperationException>(() => house.GetLocationWithHidingPlaceByName(locationName));
+                Assert.That(exception.Message, Is.EqualTo($"location with hiding place \"{locationName}\" does not exist in House"));
+            });
         }
 
         [Test]
@@ -554,6 +566,28 @@ namespace HideAndSeek
 
                 // Assert that exception message is as expected
                 Assert.That(exception.Message, Is.EqualTo($"Cannot process because data in house layout file MyInvalidDataFile is invalid - {exceptionMessageEnding}"));
+            });
+        }
+
+        [TestCaseSource(typeof(TestHouse_TestData),
+            nameof(TestHouse_TestData.TestCases_For_Test_House_CreateHouse_AndCheckErrorMessage_ForInvalidDataException_WhenFileDataHasInvalidValue_NonexistentLocation))]
+        [Category("House CreateHouse InvalidOperationException Failure")]
+        public void Test_House_CreateHouse_AndCheckErrorMessage_ForInvalidDataException_WhenFileDataHasInvalidValue_NonexistentLocation(
+            string exceptionMessageEnding, string fileText)
+        {
+            // Assign mock file system to House property
+            House.FileSystem = MockFileSystemHelper.GetMockedFileSystem_ToReadAllText("MyInvalidDataFile.json", fileText);
+
+            Assert.Multiple(() =>
+            {
+                // Assert that creating a SavedGame object with a file with an invalid value for a property throws an exception
+                var exception = Assert.Throws<InvalidOperationException>(() =>
+                {
+                    House.CreateHouse("MyInvalidDataFile");
+                });
+
+                // Assert that exception message is as expected
+                Assert.That(exception.Message, Is.EqualTo($"Cannot process because data in house layout file MyInvalidDataFile is corrupt - {exceptionMessageEnding}"));
             });
         }
 

--- a/HideAndSeekTestProject/TestHouse_TestData.cs
+++ b/HideAndSeekTestProject/TestHouse_TestData.cs
@@ -714,17 +714,6 @@ namespace HideAndSeek
         {
             get
             {
-                // Invalid PlayerStartingPoint - not a Location
-                yield return new TestCaseData("Cannot perform action because player starting point location \"Dungeon\" is not a location in the house",
-                        "{" +
-                           DefaultHouse_Serialized_Name + "," +
-                           DefaultHouse_Serialized_HouseFileName + "," +
-                           "\"PlayerStartingPoint\":\"Dungeon\"" + "," +
-                           DefaultHouse_Serialized_LocationsWithoutHidingPlaces + "," +
-                           DefaultHouse_Serialized_LocationsWithHidingPlaces +
-                       "}")
-                   .SetName("Test_House_CreateHouse_AndCheckErrorMessage_ForInvalidDataException_WhenFileDataHasInvalidValue - invalid PlayerStartingPoint - nonexistent");
-
                 // Invalid LocationsWithHidingPlaces - empty list
                 yield return new TestCaseData("Cannot perform action because locations with hiding places list is empty",
                         "{" +
@@ -813,9 +802,26 @@ namespace HideAndSeek
                            "]" +
                        "}")
                    .SetName("Test_House_CreateHouse_AndCheckErrorMessage_ForInvalidDataException_WhenFileDataHasInvalidValue - invalid LocationsWithHidingPlaces - no exits");
+            }
+        }
+
+        public static IEnumerable TestCases_For_Test_House_CreateHouse_AndCheckErrorMessage_ForInvalidDataException_WhenFileDataHasInvalidValue_NonexistentLocation
+        {
+            get
+            {
+                // Invalid PlayerStartingPoint - not a Location
+                yield return new TestCaseData("location \"Dungeon\" does not exist in House",
+                        "{" +
+                           DefaultHouse_Serialized_Name + "," +
+                           DefaultHouse_Serialized_HouseFileName + "," +
+                           "\"PlayerStartingPoint\":\"Dungeon\"" + "," +
+                           DefaultHouse_Serialized_LocationsWithoutHidingPlaces + "," +
+                           DefaultHouse_Serialized_LocationsWithHidingPlaces +
+                       "}")
+                   .SetName("Test_House_CreateHouse_AndCheckErrorMessage_ForInvalidDataException_WhenFileDataHasInvalidValue_NonexistentLocation - PlayerStartingPoint");
 
                 // Invalid LocationsWithoutHidingPlaces - Location has nonexistent exit
-                yield return new TestCaseData("Cannot perform action because \"Hallway\" exit location \"Dungeon\" in direction \"Down\" does not exist",
+                yield return new TestCaseData("location \"Dungeon\" does not exist in House",
                         "{" +
                            DefaultHouse_Serialized_Name + "," +
                            DefaultHouse_Serialized_HouseFileName + "," +
@@ -858,10 +864,10 @@ namespace HideAndSeek
                            "]" + "," +
                            DefaultHouse_Serialized_LocationsWithHidingPlaces +
                        "}")
-                   .SetName("Test_House_CreateHouse_AndCheckErrorMessage_ForInvalidDataException_WhenFileDataHasInvalidValue - invalid LocationsWithoutHidingPlaces - nonexistent exit");
+                   .SetName("Test_House_CreateHouse_AndCheckErrorMessage_ForInvalidDataException_WhenFileDataHasInvalidValue_NonexistentLocation - LocationsWithoutHidingPlaces");
 
                 // Invalid LocationsWithHidingPlaces - LocationWithHidingPlace has nonexistent exit
-                yield return new TestCaseData("Cannot perform action because \"Bathroom\" exit location \"Dungeon\" in direction \"Down\" does not exist",
+                yield return new TestCaseData("location \"Dungeon\" does not exist in House",
                         "{" +
                            DefaultHouse_Serialized_Name + "," +
                            DefaultHouse_Serialized_HouseFileName + "," +
@@ -960,7 +966,7 @@ namespace HideAndSeek
                                 "}" +
                            "]" +
                        "}")
-                   .SetName("Test_House_CreateHouse_AndCheckErrorMessage_ForInvalidDataException_WhenFileDataHasInvalidValue - invalid LocationsWithHidingPlaces - nonexistent exit");
+                   .SetName("Test_House_CreateHouse_AndCheckErrorMessage_ForInvalidDataException_WhenFileDataHasInvalidValue_NonexistentLocation - LocationsWithHidingPlaces");
             }
         }
     }

--- a/HideAndSeekTestProject/TestHouse_TestData.cs
+++ b/HideAndSeekTestProject/TestHouse_TestData.cs
@@ -455,7 +455,7 @@ namespace HideAndSeek
             return new House("my house", "DefaultHouse", "Entry", locationsWithoutHidingPlaces, locationsWithHidingPlaces);
         }
 
-        public static IEnumerable TestCases_For_Test_House_CreateHouse_AndCheckErrorMessage_ForJsonException_WhenFileFormatIsInvalid
+        public static IEnumerable TestCases_For_Test_House_CreateHouse_AndCheckErrorMessage_WhenFileFormatIsInvalid
         {
             get
             {
@@ -465,19 +465,19 @@ namespace HideAndSeek
                                               "Expected the input to start with a valid JSON token, when isFinalBlock is true. " +
                                               "Path: $ | LineNumber: 0 | BytePositionInLine: 0.",
                         "")
-                    .SetName("Test_House_CreateHouse_AndCheckErrorMessage_ForJsonException_WhenFileFormatIsInvalid - empty file");
+                    .SetName("Test_House_CreateHouse_AndCheckErrorMessage_WhenFileFormatIsInvalid - empty file");
 
                 // File with only whitespace
                 yield return new TestCaseData("The input does not contain any JSON tokens. " +
                                               "Expected the input to start with a valid JSON token, when isFinalBlock is true. " +
                                               "Path: $ | LineNumber: 0 | BytePositionInLine: 1.",
                         " ")
-                    .SetName("Test_House_CreateHouse_AndCheckErrorMessage_ForJsonException_WhenFileFormatIsInvalid - only whitespace");
+                    .SetName("Test_House_CreateHouse_AndCheckErrorMessage_WhenFileFormatIsInvalid - only whitespace");
 
                 // File with random letters and characters
                 yield return new TestCaseData("'A' is an invalid start of a value. Path: $ | LineNumber: 0 | BytePositionInLine: 0.",
                         "ABCDeaoueou[{}}({}")
-                    .SetName("Test_House_CreateHouse_AndCheckErrorMessage_ForJsonException_WhenFileFormatIsInvalid - random characters");
+                    .SetName("Test_House_CreateHouse_AndCheckErrorMessage_WhenFileFormatIsInvalid - random characters");
 
                 // MISSING PROPERTIES
                 // File missing Name
@@ -488,7 +488,7 @@ namespace HideAndSeek
                             DefaultHouse_Serialized_LocationsWithoutHidingPlaces + "," +
                             DefaultHouse_Serialized_LocationsWithHidingPlaces +
                         "}")
-                    .SetName("Test_House_CreateHouse_AndCheckErrorMessage_ForJsonException_WhenFileFormatIsInvalid - no Name");
+                    .SetName("Test_House_CreateHouse_AndCheckErrorMessage_WhenFileFormatIsInvalid - no Name");
 
                 // File missing HouseFileName
                 yield return new TestCaseData("JSON deserialization for type 'HideAndSeek.House' was missing required properties, including the following: HouseFileName",
@@ -498,7 +498,7 @@ namespace HideAndSeek
                            DefaultHouse_Serialized_LocationsWithoutHidingPlaces + "," +
                            DefaultHouse_Serialized_LocationsWithHidingPlaces +
                        "}")
-                   .SetName("Test_House_CreateHouse_AndCheckErrorMessage_ForJsonException_WhenFileFormatIsInvalid - no HouseFileName");
+                   .SetName("Test_House_CreateHouse_AndCheckErrorMessage_WhenFileFormatIsInvalid - no HouseFileName");
 
                 // File missing PlayerStartingPoint
                 yield return new TestCaseData("JSON deserialization for type 'HideAndSeek.House' was missing required properties, including the following: PlayerStartingPoint",
@@ -508,7 +508,7 @@ namespace HideAndSeek
                            DefaultHouse_Serialized_LocationsWithoutHidingPlaces + "," +
                            DefaultHouse_Serialized_LocationsWithHidingPlaces +
                        "}")
-                   .SetName("Test_House_CreateHouse_AndCheckErrorMessage_ForJsonException_WhenFileFormatIsInvalid - no PlayerStartingPoint");
+                   .SetName("Test_House_CreateHouse_AndCheckErrorMessage_WhenFileFormatIsInvalid - no PlayerStartingPoint");
 
                 // File missing LocationsWithoutHidingPlaces
                 yield return new TestCaseData("JSON deserialization for type 'HideAndSeek.House' was missing required properties, including the following: LocationsWithoutHidingPlaces",
@@ -518,7 +518,7 @@ namespace HideAndSeek
                            DefaultHouse_Serialized_PlayerStartingPoint + "," +
                            DefaultHouse_Serialized_LocationsWithHidingPlaces +
                        "}")
-                   .SetName("Test_House_CreateHouse_AndCheckErrorMessage_ForJsonException_WhenFileFormatIsInvalid - no LocationsWithoutHidingPlaces");
+                   .SetName("Test_House_CreateHouse_AndCheckErrorMessage_WhenFileFormatIsInvalid - no LocationsWithoutHidingPlaces");
 
                 // File missing LocationsWithHidingPlaces
                 yield return new TestCaseData("JSON deserialization for type 'HideAndSeek.House' was missing required properties, including the following: LocationsWithHidingPlaces",
@@ -528,16 +528,16 @@ namespace HideAndSeek
                            DefaultHouse_Serialized_PlayerStartingPoint + "," +
                            DefaultHouse_Serialized_LocationsWithoutHidingPlaces +
                        "}")
-                   .SetName("Test_House_CreateHouse_AndCheckErrorMessage_ForJsonException_WhenFileFormatIsInvalid - no LocationsWithHidingPlaces");
+                   .SetName("Test_House_CreateHouse_AndCheckErrorMessage_WhenFileFormatIsInvalid - no LocationsWithHidingPlaces");
             }
         }
 
-        public static IEnumerable TestCases_For_Test_House_CreateHouse_AndCheckErrorMessage_ForInvalidDataException_WhenFileDataHasWhitespaceValue
+        public static IEnumerable TestCases_For_Test_House_CreateHouse_AndCheckErrorMessage_WhenFileDataHasWhitespaceValue
         {
             get
             {
                 // Invalid Name (whitespace)
-                yield return new TestCaseData("Cannot perform action because house name \" \" is invalid (is empty or contains only whitespace)",
+                yield return new TestCaseData("house name \" \" is invalid (is empty or contains only whitespace)",
                         "{" +
                            "\"Name\":\" \"" + "," +
                            DefaultHouse_Serialized_HouseFileName + "," +
@@ -545,10 +545,10 @@ namespace HideAndSeek
                            DefaultHouse_Serialized_LocationsWithoutHidingPlaces + "," +
                            DefaultHouse_Serialized_LocationsWithHidingPlaces +
                        "}")
-                   .SetName("Test_House_CreateHouse_AndCheckErrorMessage_ForInvalidDataException_WhenFileDataHasWhitespaceValue - invalid Name - whitespace");
+                   .SetName("Test_House_CreateHouse_AndCheckErrorMessage_WhenFileDataHasWhitespaceValue - invalid Name - whitespace");
 
                 // Invalid HouseFileName (whitespace)
-                yield return new TestCaseData("Cannot perform action because house file name \" \" is invalid (is empty or contains illegal characters, e.g. \\, /, or whitespace)",
+                yield return new TestCaseData("house file name \" \" is invalid (is empty or contains illegal characters, e.g. \\, /, or whitespace)",
                         "{" +
                            DefaultHouse_Serialized_Name + "," +
                            "\"HouseFileName\":\" \"" + "," +
@@ -556,10 +556,10 @@ namespace HideAndSeek
                            DefaultHouse_Serialized_LocationsWithoutHidingPlaces + "," +
                            DefaultHouse_Serialized_LocationsWithHidingPlaces +
                        "}")
-                   .SetName("Test_House_CreateHouse_AndCheckErrorMessage_ForInvalidDataException_WhenFileDataHasWhitespaceValue - invalid HouseFileName - whitespace");
+                   .SetName("Test_House_CreateHouse_AndCheckErrorMessage_WhenFileDataHasWhitespaceValue - invalid HouseFileName - whitespace");
 
                 // Invalid PlayerStartingPoint (whitespace)
-                yield return new TestCaseData("Cannot perform action because player starting point location name \" \" is invalid (is empty or contains only whitespace)",
+                yield return new TestCaseData("player starting point location name \" \" is invalid (is empty or contains only whitespace)",
                         "{" +
                            DefaultHouse_Serialized_Name + "," +
                            DefaultHouse_Serialized_HouseFileName + "," +
@@ -567,10 +567,10 @@ namespace HideAndSeek
                            DefaultHouse_Serialized_LocationsWithoutHidingPlaces + "," +
                            DefaultHouse_Serialized_LocationsWithHidingPlaces +
                        "}")
-                   .SetName("Test_House_CreateHouse_AndCheckErrorMessage_ForInvalidDataException_WhenFileDataHasWhitespaceValue - invalid PlayerStartingPoint - whitespace");
+                   .SetName("Test_House_CreateHouse_AndCheckErrorMessage_WhenFileDataHasWhitespaceValue - invalid PlayerStartingPoint - whitespace");
 
                 // Invalid LocationsWithoutHidingPlaces - Location name is invalid (whitespace)
-                yield return new TestCaseData("Cannot perform action because location name \" \" is invalid (is empty or contains only whitespace)",
+                yield return new TestCaseData("location name \" \" is invalid (is empty or contains only whitespace)",
                         "{" +
                            DefaultHouse_Serialized_Name + "," +
                            DefaultHouse_Serialized_HouseFileName + "," +
@@ -591,10 +591,10 @@ namespace HideAndSeek
                            "]" + "," +
                            DefaultHouse_Serialized_LocationsWithHidingPlaces +
                        "}")
-                   .SetName("Test_House_CreateHouse_AndCheckErrorMessage_ForInvalidDataException_WhenFileDataHasWhitespaceValue - LocationsWithoutHidingPlaces - invalid Location Name - whitespace");
+                   .SetName("Test_House_CreateHouse_AndCheckErrorMessage_WhenFileDataHasWhitespaceValue - LocationsWithoutHidingPlaces - invalid Location Name - whitespace");
 
                 // Invalid LocationsWithHidingPlaces - LocationWithHidingPlace name in invalid (whitespace)
-                yield return new TestCaseData("Cannot perform action because location name \" \" is invalid (is empty or contains only whitespace)",
+                yield return new TestCaseData("location name \" \" is invalid (is empty or contains only whitespace)",
                         "{" +
                            DefaultHouse_Serialized_Name + "," +
                            DefaultHouse_Serialized_HouseFileName + "," +
@@ -612,10 +612,10 @@ namespace HideAndSeek
                                 "}" +
                             "]" +
                        "}")
-                   .SetName("Test_House_CreateHouse_AndCheckErrorMessage_ForInvalidDataException_WhenFileDataHasWhitespaceValue - LocationsWithHidingPlaces - invalid Location Name - whitespace");
+                   .SetName("Test_House_CreateHouse_AndCheckErrorMessage_WhenFileDataHasWhitespaceValue - LocationsWithHidingPlaces - invalid Location Name - whitespace");
 
                 // Invalid LocationsWithHidingPlaces - LocationWithHidingPlace description is invalid (whitespace)
-                yield return new TestCaseData("Cannot perform action because hiding place \" \" is invalid (is empty or contains only whitespace)",
+                yield return new TestCaseData("hiding place \" \" is invalid (is empty or contains only whitespace)",
                         "{" +
                            DefaultHouse_Serialized_Name + "," +
                            DefaultHouse_Serialized_HouseFileName + "," +
@@ -633,11 +633,11 @@ namespace HideAndSeek
                                 "}" +
                             "]" +
                        "}")
-                   .SetName("Test_House_CreateHouse_AndCheckErrorMessage_ForInvalidDataException_WhenFileDataHasWhitespaceValue - LocationsWithHidingPlaces - invalid Location HidingPlace - whitespace");
+                   .SetName("Test_House_CreateHouse_AndCheckErrorMessage_WhenFileDataHasWhitespaceValue - LocationsWithHidingPlaces - invalid Location HidingPlace - whitespace");
             }
         }
 
-        public static IEnumerable TestCases_For_Test_House_CreateHouse_AndCheckErrorMessage_ForJsonException_WhenFileDataHasInvalidDirection
+        public static IEnumerable TestCases_For_Test_House_CreateHouse_AndCheckErrorMessage_WhenFileDataHasInvalidDirection
         {
             get
             {
@@ -676,7 +676,7 @@ namespace HideAndSeek
                                 "}" +
                            "]" +
                        "}")
-                   .SetName("Test_House_CreateHouse_AndCheckErrorMessage_ForJsonException_WhenFileDataHasInvalidDirection - LocationsWithoutHidingPlaces");
+                   .SetName("Test_House_CreateHouse_AndCheckErrorMessage_WhenFileDataHasInvalidDirection - LocationsWithoutHidingPlaces");
 
                 // Invalid LocationsWithHidingPlaces - exit direction is invalid
                 yield return new TestCaseData("{" +
@@ -706,16 +706,16 @@ namespace HideAndSeek
                                 "}" +
                             "]" +
                         "}")
-                   .SetName("Test_House_CreateHouse_AndCheckErrorMessage_ForJsonException_WhenFileDataHasInvalidDirection - LocationsWithHidingPlaces");
+                   .SetName("Test_House_CreateHouse_AndCheckErrorMessage_WhenFileDataHasInvalidDirection - LocationsWithHidingPlaces");
             }
         }
 
-        public static IEnumerable TestCases_For_Test_House_CreateHouse_AndCheckErrorMessage_ForInvalidDataException_WhenFileDataHasInvalidValue
+        public static IEnumerable TestCases_For_Test_House_CreateHouse_AndCheckErrorMessage_WhenFileDataHasInvalidValue
         {
             get
             {
                 // Invalid LocationsWithHidingPlaces - empty list
-                yield return new TestCaseData("Cannot perform action because locations with hiding places list is empty",
+                yield return new TestCaseData("locations with hiding places list is empty",
                         "{" +
                            DefaultHouse_Serialized_Name + "," +
                            DefaultHouse_Serialized_HouseFileName + "," +
@@ -741,10 +741,10 @@ namespace HideAndSeek
                            "[" +
                            "]" +
                        "}")
-                   .SetName("Test_House_CreateHouse_AndCheckErrorMessage_ForInvalidDataException_WhenFileDataHasInvalidValue - invalid LocationsWithHidingPlaces - empty");
+                   .SetName("Test_House_CreateHouse_AndCheckErrorMessage_WhenFileDataHasInvalidValue - invalid LocationsWithHidingPlaces - empty");
 
                 // Invalid LocationsWithoutHidingPlaces - Location has no exits
-                yield return new TestCaseData("Cannot perform action because location \"Hallway\" must be assigned at least one exit",
+                yield return new TestCaseData("location \"Hallway\" must be assigned at least one exit",
                         "{" +
                            DefaultHouse_Serialized_Name + "," +
                            DefaultHouse_Serialized_HouseFileName + "," +
@@ -781,10 +781,10 @@ namespace HideAndSeek
                            "]" + "," +
                            DefaultHouse_Serialized_LocationsWithHidingPlaces +
                        "}")
-                   .SetName("Test_House_CreateHouse_AndCheckErrorMessage_ForInvalidDataException_WhenFileDataHasInvalidValue - invalid LocationsWithoutHidingPlaces - no exits");
+                   .SetName("Test_House_CreateHouse_AndCheckErrorMessage_WhenFileDataHasInvalidValue - invalid LocationsWithoutHidingPlaces - no exits");
 
                 // Invalid LocationsWithHidingPlaces - LocationWithHidingPlace has no exits
-                yield return new TestCaseData("Cannot perform action because location \"Attic\" must be assigned at least one exit",
+                yield return new TestCaseData("location \"Attic\" must be assigned at least one exit",
                         "{" +
                            DefaultHouse_Serialized_Name + "," +
                            DefaultHouse_Serialized_HouseFileName + "," +
@@ -801,16 +801,16 @@ namespace HideAndSeek
                                 "}" +
                            "]" +
                        "}")
-                   .SetName("Test_House_CreateHouse_AndCheckErrorMessage_ForInvalidDataException_WhenFileDataHasInvalidValue - invalid LocationsWithHidingPlaces - no exits");
+                   .SetName("Test_House_CreateHouse_AndCheckErrorMessage_WhenFileDataHasInvalidValue - invalid LocationsWithHidingPlaces - no exits");
             }
         }
 
-        public static IEnumerable TestCases_For_Test_House_CreateHouse_AndCheckErrorMessage_ForInvalidDataException_WhenFileDataHasInvalidValue_NonexistentLocation
+        public static IEnumerable TestCases_For_Test_House_CreateHouse_AndCheckErrorMessage_WhenFileDataHasInvalidValue_NonexistentLocation
         {
             get
             {
                 // Invalid PlayerStartingPoint - not a Location
-                yield return new TestCaseData("location \"Dungeon\" does not exist in House",
+                yield return new TestCaseData("player starting point location \"Dungeon\" does not exist in House",
                         "{" +
                            DefaultHouse_Serialized_Name + "," +
                            DefaultHouse_Serialized_HouseFileName + "," +
@@ -818,10 +818,10 @@ namespace HideAndSeek
                            DefaultHouse_Serialized_LocationsWithoutHidingPlaces + "," +
                            DefaultHouse_Serialized_LocationsWithHidingPlaces +
                        "}")
-                   .SetName("Test_House_CreateHouse_AndCheckErrorMessage_ForInvalidDataException_WhenFileDataHasInvalidValue_NonexistentLocation - PlayerStartingPoint");
+                   .SetName("Test_House_CreateHouse_AndCheckErrorMessage_WhenFileDataHasInvalidValue_NonexistentLocation - PlayerStartingPoint");
 
                 // Invalid LocationsWithoutHidingPlaces - Location has nonexistent exit
-                yield return new TestCaseData("location \"Dungeon\" does not exist in House",
+                yield return new TestCaseData("\"Hallway\" exit location \"Dungeon\" in direction \"Down\" does not exist",
                         "{" +
                            DefaultHouse_Serialized_Name + "," +
                            DefaultHouse_Serialized_HouseFileName + "," +
@@ -864,10 +864,10 @@ namespace HideAndSeek
                            "]" + "," +
                            DefaultHouse_Serialized_LocationsWithHidingPlaces +
                        "}")
-                   .SetName("Test_House_CreateHouse_AndCheckErrorMessage_ForInvalidDataException_WhenFileDataHasInvalidValue_NonexistentLocation - LocationsWithoutHidingPlaces");
+                   .SetName("Test_House_CreateHouse_AndCheckErrorMessage_WhenFileDataHasInvalidValue_NonexistentLocation - LocationsWithoutHidingPlaces");
 
                 // Invalid LocationsWithHidingPlaces - LocationWithHidingPlace has nonexistent exit
-                yield return new TestCaseData("location \"Dungeon\" does not exist in House",
+                yield return new TestCaseData("\"Bathroom\" exit location \"Dungeon\" in direction \"Down\" does not exist",
                         "{" +
                            DefaultHouse_Serialized_Name + "," +
                            DefaultHouse_Serialized_HouseFileName + "," +
@@ -966,7 +966,7 @@ namespace HideAndSeek
                                 "}" +
                            "]" +
                        "}")
-                   .SetName("Test_House_CreateHouse_AndCheckErrorMessage_ForInvalidDataException_WhenFileDataHasInvalidValue_NonexistentLocation - LocationsWithHidingPlaces");
+                   .SetName("Test_House_CreateHouse_AndCheckErrorMessage_WhenFileDataHasInvalidValue_NonexistentLocation - LocationsWithHidingPlaces");
             }
         }
     }

--- a/HideAndSeekTestProject/TestLocation.cs
+++ b/HideAndSeekTestProject/TestLocation.cs
@@ -132,7 +132,7 @@ namespace HideAndSeek
         }
 
         [Test]
-        [Category("Location GetExit Failure")]
+        [Category("Location GetExit InvalidOperationException Failure")]
         public void Test_Location_GetExit_AndCheckErrorMessage_WhenNoLocationInDirection()
         {
             Assert.Multiple(() =>
@@ -347,27 +347,26 @@ namespace HideAndSeek
 
         [TestCase("")]
         [TestCase(" ")]
-        [Category("Location Name Failure")]
+        [Category("Location Name ArgumentException Failure")]
         public void Test_Location_Set_Name_AndCheckErrorMessage_ForInvalidName(string name)
         {
             Assert.Multiple(() =>
             {
                 // Assert that setting the Name to an invalid name raises exception
-                var exception = Assert.Throws<InvalidDataException>(() =>
+                var exception = Assert.Throws<ArgumentException>(() =>
                 {
                     center.Name = name;
                 });
 
                 // Assert that exception message is as expected
-                Assert.That(exception.Message, Is.EqualTo($"Cannot perform action because location name \"{name}\" is invalid " +
-                                                           "(is empty or contains only whitespace)"));
+                Assert.That(exception.Message, Does.StartWith($"location name \"{name}\" is invalid (is empty or contains only whitespace)"));
             });
         }
 
         // The test for successful set ExitsForSerialization is in deserialization test
         [TestCase("")]
         [TestCase(" ")]
-        [Category("Location ExitsForSerialization Failure")]
+        [Category("Location ExitsForSerialization ArgumentException Failure")]
         public void Test_Location_Set_ExitsForSerialization_AndCheckErrorMessage_ForInvalidExitLocationName(string locationName)
         {
             // Create dictionary of exits
@@ -378,14 +377,14 @@ namespace HideAndSeek
             Assert.Multiple(() =>
             {
                 // Assert that setting the ExitsForSerialization property to a dictionary with an invalid location name raises an exception
-                var exception = Assert.Throws<InvalidDataException>(() =>
+                var exception = Assert.Throws<ArgumentException>(() =>
                 {
                     center.ExitsForSerialization = exits;
                 });
 
                 // Assert that exception message is as expected
-                Assert.That(exception.Message, Is.EqualTo($"Cannot perform action because location name \"{locationName}\" " +
-                                                           "for exit in direction \"North\" is invalid (is empty or contains only whitespace"));
+                Assert.That(exception.Message, Does.StartWith($"location name \"{locationName}\" for exit in direction \"North\" " +
+                                                           "is invalid (is empty or contains only whitespace"));
             });
         }
 
@@ -406,20 +405,19 @@ namespace HideAndSeek
         }
 
         [Test]
-        [Category("Location SetExitsDictionary Failure")]
+        [Category("Location SetExitsDictionary ArgumentException Failure")]
         public void Test_Location_SetExitsDictionary_AndCheckErrorMessage_ForEmptyDictionary()
         {
             Assert.Multiple(() =>
             {
                 // Assert that setting exits dictionary to empty dictionary raises exception
-                var exception = Assert.Throws<InvalidDataException>(() =>
+                var exception = Assert.Throws<ArgumentException>(() =>
                 {
                     center.SetExitsDictionary(new Dictionary<Direction, Location>());
                 });
 
                 // Assert that exception message is as expected
-                Assert.That(exception.Message, Is.EqualTo("Cannot perform action because location \"living room\" " +
-                                                          "must be assigned at least one exit"));
+                Assert.That(exception.Message, Does.StartWith("location \"living room\" must be assigned at least one exit"));
             });
         }
 
@@ -507,7 +505,7 @@ namespace HideAndSeek
 
         [TestCase("")]
         [TestCase(" ")]
-        [Category("Location Deserialization Failure")]
+        [Category("Location Deserialization ArgumentException Failure")]
         public void Test_Location_Deserialization_AndCheckErrorMessage_ForInvalidName(string name)
         {
             // Set expected ExitsForSerialization property value
@@ -526,20 +524,19 @@ namespace HideAndSeek
             Assert.Multiple(() =>
             {
                 // Assert that deserializing raises exception
-                var exception = Assert.Throws<InvalidDataException>(() =>
+                var exception = Assert.Throws<ArgumentException>(() =>
                 {
                     JsonSerializer.Deserialize<Location>(serializedLocation);
                 });
 
                 // Assert that exception message is as expected
-                Assert.That(exception.Message, Is.EqualTo($"Cannot perform action because location name \"{name}\" " +
-                                                          $"is invalid (is empty or contains only whitespace)"));
+                Assert.That(exception.Message, Does.StartWith($"location name \"{name}\" is invalid (is empty or contains only whitespace)"));
             });
         }
 
         [TestCase("")]
         [TestCase(" ")]
-        [Category("Location Deserialization Failure")]
+        [Category("Location Deserialization ArgumentException Failure")]
         public void Test_Location_Deserialization_AndCheckErrorMessage_ForInvalidExitLocationName(string name)
         {
             // Text representing serialized Location
@@ -554,14 +551,14 @@ namespace HideAndSeek
             Assert.Multiple(() =>
             {
                 // Assert that deserializing raises exception
-                var exception = Assert.Throws<InvalidDataException>(() =>
+                var exception = Assert.Throws<ArgumentException>(() =>
                 {
                     JsonSerializer.Deserialize<Location>(serializedLocation);
                 });
 
                 // Assert that exception message is as expected
-                Assert.That(exception.Message, Is.EqualTo($"Cannot perform action because location name \"{name}\" " +
-                                                           "for exit in direction \"North\" is invalid (is empty or contains only whitespace"));
+                Assert.That(exception.Message, Does.StartWith($"location name \"{name}\" for exit in direction \"North\" " +
+                                                               "is invalid (is empty or contains only whitespace"));
             });
         }
     }

--- a/HideAndSeekTestProject/TestLocationWithHidingPlace.cs
+++ b/HideAndSeekTestProject/TestLocationWithHidingPlace.cs
@@ -75,7 +75,7 @@ namespace HideAndSeek
 
         [TestCase("")]
         [TestCase(" ")]
-        [Category("LocationWithHidingPlace HidingPlace Failure")]
+        [Category("LocationWithHidingPlace HidingPlace ArgumentException Failure")]
         public void Test_LocationWithHidingPlace_Set_HidingPlace_AndCheckErrorMessage_ForInvalidDescription(string description)
         {
             // Create LocationWithHidingPlace
@@ -84,14 +84,13 @@ namespace HideAndSeek
             Assert.Multiple(() =>
             {
                 // Assert that setting the hiding place to an invalid description throws exception
-                var exception = Assert.Throws<InvalidDataException>(() =>
+                var exception = Assert.Throws<ArgumentException>(() =>
                 {
                     locationWithHidingPlace.HidingPlace = description;
                 });
 
                 // Assert that exception message is as expected
-                Assert.That(exception.Message, Is.EqualTo($"Cannot perform action because hiding place \"{description}\" is invalid " +
-                                                           "(is empty or contains only whitespace)"));
+                Assert.That(exception.Message, Does.StartWith($"hiding place \"{description}\" is invalid (is empty or contains only whitespace)"));
             });
         }
 
@@ -183,7 +182,7 @@ namespace HideAndSeek
         // Tests HidingLocation data validation
         [TestCase("")]
         [TestCase(" ")]
-        [Category("LocationWithHidingPlace Deserialize Failure")]
+        [Category("LocationWithHidingPlace Deserialize ArgumentException Failure")]
         public void Test_LocationWithHidingPlace_Deserialize_AndCheckErrorMessage_ForInvalidHidingLocation(string hidingPlace)
         {
             // Initialize to expected ExitsForSerialization property value
@@ -203,14 +202,13 @@ namespace HideAndSeek
             Assert.Multiple(() =>
             {
                 // Assert that deserializing raises exception
-                var exception = Assert.Throws<InvalidDataException>(() =>
+                var exception = Assert.Throws<ArgumentException>(() =>
                 {
                     JsonSerializer.Deserialize<LocationWithHidingPlace>(serializedLocation);
                 });
 
                 // Assert that exception message is as expected
-                Assert.That(exception.Message, Is.EqualTo($"Cannot perform action because hiding place \"{hidingPlace}\" is invalid " +
-                                                           "(is empty or contains only whitespace)"));
+                Assert.That(exception.Message, Does.StartWith($"hiding place \"{hidingPlace}\" is invalid (is empty or contains only whitespace)"));
             });
         }
 

--- a/HideAndSeekTestProject/TestOpponent.cs
+++ b/HideAndSeekTestProject/TestOpponent.cs
@@ -46,20 +46,19 @@ namespace HideAndSeek
 
         [TestCase("")]
         [TestCase(" ")]
-        [Category("Opponent Constructor Name Failure")]
+        [Category("Opponent Constructor Name ArgumentException Failure")]
         public void Test_Opponent_Constructor_Parameterized_AndCheckErrorMessage_ForInvalidName(string name)
         {
             Assert.Multiple(() =>
             {
                 // Assert that creating a new opponent with an invalid name raises exception
-                var exception = Assert.Throws<InvalidDataException>(() =>
+                var exception = Assert.Throws<ArgumentException>(() =>
                 {
                     new Opponent(name);
                 });
 
                 // Assert that exception message is as expected
-                Assert.That(exception.Message, Is.EqualTo($"Cannot perform action because opponent name \"{name}\" is invalid " +
-                                                           "(is empty or contains only whitespace)"));
+                Assert.That(exception.Message, Does.StartWith($"opponent name \"{name}\" is invalid (is empty or contains only whitespace)"));
             });
         }
     }

--- a/HideAndSeekTestProject/TestSavedGame_Basic.cs
+++ b/HideAndSeekTestProject/TestSavedGame_Basic.cs
@@ -66,25 +66,25 @@ namespace HideAndSeek
         [TestCase("/myFile")]
         [TestCase("myFile/")]
         [TestCase("my/File")]
-        [Category("SavedGame Constructor Failure")]
+        [Category("SavedGame Constructor ArgumentException Failure")]
         public void Test_SavedGame_Constructor_WithHouse_AndHouseFileName_AndCheckErrorMessage_ForInvalidFileName(string fileName)
         {
             Assert.Multiple(() =>
             {
                 // Assert that creating a SavedGame object with an invalid file name raises an exception
-                var exception = Assert.Throws<InvalidDataException>(() =>
+                var exception = Assert.Throws<ArgumentException>(() =>
                 {
                     savedGame = new SavedGame(GetDefaultHouse(), fileName, "Entry", 1, opponentsAndHidingPlaces, new List<string>());
                 });
 
                 // Assert that exception message is as expected
-                Assert.That(exception.Message, Is.EqualTo($"House file name \"{fileName}\" is invalid " +
-                                                           "(is empty or contains illegal characters, e.g. \\, /, or whitespace)"));
+                Assert.That(exception.Message, Does.StartWith($"House file name \"{fileName}\" is invalid " +
+                                                               "(is empty or contains illegal characters, e.g. \\, /, or whitespace)"));
             });
         }
 
         [Test]
-        [Category("SavedGame House Failure")]
+        [Category("SavedGame House InvalidOperationException Failure")]
         public void Test_SavedGame_Set_House_AndCheckErrorMessage_ForAlreadyHasValue()
         {
             // Create new SavedGame (giving House property's backing field a value)
@@ -104,7 +104,7 @@ namespace HideAndSeek
         }
 
         [Test]
-        [Category("SavedGame HouseFileName Failure")]
+        [Category("SavedGame HouseFileName InvalidOperationException Failure")]
         public void Test_SavedGame_Set_HouseFileName_AndCheckErrorMessage_ForAlreadyHasValue()
         {
             // Create new SavedGame (giving HouseFileName property's backing field a value)
@@ -143,19 +143,19 @@ namespace HideAndSeek
         }
 
         [Test]
-        [Category("SavedGame PlayerLocation Failure")]
+        [Category("SavedGame PlayerLocation InvalidOperationException Failure")]
         public void Test_SavedGame_Set_PlayerLocation_AndCheckErrorMessage_ForInvalidValue()
         {
             Assert.Multiple(() =>
             {
                 // Assert that creating a SavedGame object with invalid player location raises an exception
-                var exception = Assert.Throws<InvalidDataException>(() =>
+                var exception = Assert.Throws<InvalidOperationException>(() =>
                 {
                     savedGame = new SavedGame(GetDefaultHouse(), "TestHouse", "Alaska", 1, opponentsAndHidingPlaces, new List<string>());
                 });
 
                 // Assert that exception message is as expected
-                Assert.That(exception.Message, Is.EqualTo("invalid PlayerLocation"));
+                Assert.That(exception.Message, Is.EqualTo("invalid PlayerLocation - location \"Alaska\" does not exist in House"));
             });
         }
 
@@ -180,19 +180,19 @@ namespace HideAndSeek
         [TestCase(0)]
         [TestCase(-1)]
         [TestCase(-1000)]
-        [Category("SavedGame MoveNumber Failure")]
+        [Category("SavedGame MoveNumber ArgumentOutOfRangeException Failure")]
         public void Test_SavedGame_Set_MoveNumber_AndCheckErrorMessage_ForInvalidValue(int moveNumber)
         {
             Assert.Multiple(() =>
             {
                 // Assert that creating a SavedGame object with invalid move number raises an exception
-                var exception = Assert.Throws<InvalidDataException>(() =>
+                var exception = Assert.Throws<ArgumentOutOfRangeException>(() =>
                 {
                     savedGame = new SavedGame(GetDefaultHouse(), "TestHouse", "Entry", moveNumber, opponentsAndHidingPlaces, new List<string>());
                 });
 
                 // Assert that exception message is as expected
-                Assert.That(exception.Message, Is.EqualTo("invalid MoveNumber"));
+                Assert.That(exception.Message, Does.StartWith("MoveNumber is invalid - must be positive number"));
             });
         }
 
@@ -231,30 +231,30 @@ namespace HideAndSeek
         }
 
         [Test]
-        [Category("SavedGame OpponentsAndHidingLocations Failure")]
+        [Category("SavedGame OpponentsAndHidingLocations ArgumentException Failure")]
         public void Test_SavedGame_Set_OpponentsAndHidingPlaces_AndCheckErrorMessage_ForEmptyDictionary()
         {
             Assert.Multiple(() =>
             {
                 // Assert that creating a SavedGame object with empty dictionary for OpponentsAndHidingLocations raises an exception
-                var exception = Assert.Throws<InvalidDataException>(() =>
+                var exception = Assert.Throws<ArgumentException>(() =>
                 {
                     savedGame = new SavedGame(GetDefaultHouse(), "TestHouse", "Entry", 1, 
                                               new Dictionary<string, string>(), new List<string>());
                 });
 
                 // Assert that exception message is as expected
-                Assert.That(exception.Message, Is.EqualTo("no opponents"));
+                Assert.That(exception.Message, Does.StartWith("invalid OpponentsAndHidingLocations - no opponents"));
             });
         }
 
         [TestCase("Dungeon", "Living Room", "Attic", "Kitchen", "Pantry")]
         [TestCase("Living Room", "Dungeon", "Attic", "Kitchen", "Pantry")]
         [TestCase("Bathroom", "Second Bathroom", "Dungeon", "Living Room", "Garage")]
-        [TestCase("Kids Room", "Nursery", "Master Bathroom", "Dungeon", "Master Bedroom")]
-        [TestCase("Kids Room", "Nursery", "Master Bathroom", "Master Bedroom", "Dungeon")]
-        [TestCase("Dungeon", "Dungeon", "Master Bathroom", "Master Bedroom", "Pantry")]
-        [Category("SavedGame OpponentsAndHidingLocations Failure")]
+        [TestCase("Kids Room", "Nursery", "Nursery", "Dungeon", "Master Bedroom")]
+        [TestCase("Kids Room", "Nursery", "Nursery", "Master Bedroom", "Dungeon")]
+        [TestCase("Dungeon", "Dungeon", "Nursery", "Master Bedroom", "Pantry")]
+        [Category("SavedGame OpponentsAndHidingLocations InvalidOperationException Failure")]
         public void Test_SavedGame_Set_OpponentsAndHidingPlaces_AndCheckErrorMessage_ForNonexistentLocation
             (string location1, string location2, string location3, string location4, string location5)
         {
@@ -269,18 +269,18 @@ namespace HideAndSeek
             Assert.Multiple(() =>
             {
                 // Assert that creating a SavedGame object with nonexistent (invalid) opponent hiding place/s raises an exception
-                var exception = Assert.Throws<InvalidDataException>(() =>
+                var exception = Assert.Throws<InvalidOperationException>(() =>
                 {
                     savedGame = new SavedGame(GetDefaultHouse(), "TestHouse", "Entry", 1, invalidOpponentsAndHidingPlaces, new List<string>());
                 });
 
                 // Assert that exception message is as expected
-                Assert.That(exception.Message, Is.EqualTo("invalid hiding location for opponent"));
+                Assert.That(exception.Message, Is.EqualTo("location with hiding place \"Dungeon\" does not exist in House"));
             });
         }
 
         [Test]
-        [Category("SavedGame OpponentsAndHidingLocations Failure")]
+        [Category("SavedGame OpponentsAndHidingLocations InvalidOperationException Failure")]
         public void Test_SavedGame_Set_OpponentsAndHidingPlaces_AndCheckErrorMessage_ForLocationWithoutHidingPlace()
         {
             // Create dictionary of opponents with invalid hiding places (locations without hiding places)
@@ -294,13 +294,13 @@ namespace HideAndSeek
             Assert.Multiple(() =>
             {
                 // Assert that creating a SavedGame object with opponent hiding locations that don't have hiding places raises an exception
-                var exception = Assert.Throws<InvalidDataException>(() =>
+                var exception = Assert.Throws<InvalidOperationException>(() =>
                 {
                     savedGame = new SavedGame(GetDefaultHouse(), "TestHouse", "Entry", 1, invalidOpponentsAndHidingPlaces, new List<string>());
                 });
 
                 // Assert that exception message is as expected
-                Assert.That(exception.Message, Is.EqualTo("invalid hiding location for opponent"));
+                Assert.That(exception.Message, Is.EqualTo("location with hiding place \"Entry\" does not exist in House"));
             });
         }
 
@@ -380,7 +380,7 @@ namespace HideAndSeek
         [TestCase("Joe", "Bob", "Methuselah", "Owen", "Jimmy")]
         [TestCase("Joe", "Bob", "Ana", "Methuselah", "Jimmy")]
         [TestCase("Joe", "Bob", "Ana", "Owen", "Methuselah")]
-        [Category("SavedGame FoundOpponents Failure")]
+        [Category("SavedGame FoundOpponents InvalidOperationException Failure")]
         public void Test_SavedGame_Set_FoundOpponents_AndCheckErrorMessage_ForNonexistentOpponent(params string[] foundOpponents)
         {
             // Convert array of found opponents (including invalid, nonexistent opponent) to list
@@ -397,7 +397,7 @@ namespace HideAndSeek
             Assert.Multiple(() =>
             {
                 // Assert that creating a SavedGame object with nonexistent found opponent raises an exception
-                var exception = Assert.Throws<InvalidDataException>(() =>
+                var exception = Assert.Throws<InvalidOperationException>(() =>
                 {
                     savedGame = new SavedGame(GetDefaultHouse(), "TestHouse", "Entry", 1, validOpponentsAndHidingPlaces, foundOpponentsAsList);
                 });

--- a/HideAndSeekTestProject/TestSavedGame_SerializationAndDeserialization.cs
+++ b/HideAndSeekTestProject/TestSavedGame_SerializationAndDeserialization.cs
@@ -241,6 +241,35 @@ namespace HideAndSeek
             });
         }
 
+        [Test]
+        [Category("SavedGame Deserialize ArgumentException Failure")]
+        public void Test_SavedGame_Deserialize_AndCheckErrorMessage_ForInvalidDataException_WhenFileDataHasInvalidValue_ForHouseFileName()
+        {
+            // Set House file system to mock file system to return text in file
+            House.FileSystem = MockFileSystemHelper.GetMockedFileSystem_ToReadAllText("DefaultHouse.json",
+                                    TestSavedGame_SerializationAndDeserialization_TestData.DefaultHouse_Serialized);
+
+            Assert.Multiple(() =>
+            {
+                // Assert that deserialization raises an exception
+                var exception = Assert.Throws<ArgumentException>(() =>
+                {
+                    JsonSerializer.Deserialize<SavedGame>(
+                        "{" +
+                            "\"HouseFileName\":\"a8}{{ /@uaou12 \"" + "," +
+                            TestSavedGame_SerializationAndDeserialization_TestData.SavedGame_Serialized_PlayerLocation_NoFoundOpponents + "," +
+                            TestSavedGame_SerializationAndDeserialization_TestData.SavedGame_Serialized_MoveNumber_NoFoundOpponents + "," +
+                            TestSavedGame_SerializationAndDeserialization_TestData.SavedGame_Serialized_OpponentsAndHidingLocations + "," +
+                            TestSavedGame_SerializationAndDeserialization_TestData.SavedGame_Serialized_FoundOpponents_NoFoundOpponents +
+                        "}");
+                });
+
+                // Assert that exception message is as expected
+                Assert.That(exception.Message, Is.EqualTo("Cannot perform action because file name \"a8}{{ /@uaou12 \" is invalid " +
+                                                          "(is empty or contains illegal characters, e.g. \\, /, or whitespace)"));
+            });
+        }
+
         [TestCaseSource(typeof(TestSavedGame_SerializationAndDeserialization_TestData), nameof(TestSavedGame_SerializationAndDeserialization_TestData.TestCases_For_Test_SavedGame_Deserialize_AndCheckErrorMessage_ForJsonException_WhenHouseFileFormatIsInvalid))]
         [Category("SavedGame Deserialize House Failure")]
         public void Test_SavedGame_Deserialize_AndCheckErrorMessage_ForJsonException_WhenHouseFileFormatIsInvalid(string exceptionMessageEnding, string houseFileText)

--- a/HideAndSeekTestProject/TestSavedGame_SerializationAndDeserialization.cs
+++ b/HideAndSeekTestProject/TestSavedGame_SerializationAndDeserialization.cs
@@ -157,8 +157,8 @@ namespace HideAndSeek
 
         // Tests all properties' setters and House getter
         [Test]
-        [Category("SavedGame Deserialize Failure")]
-        public void Test_SavedGame_Deserialize_AndCheckErrorMessage_ForNullReferenceException_ForMissingHouseFileName()
+        [Category("SavedGame Deserialize NullReferenceException Failure")]
+        public void Test_SavedGame_Deserialize_AndCheckErrorMessage_WhenMissingHouseFileName()
         {
             // Initialize variable to text representing serialized SavedGame
             string textInFile =
@@ -182,9 +182,10 @@ namespace HideAndSeek
             });
         }
 
-        [TestCaseSource(typeof(TestSavedGame_SerializationAndDeserialization_TestData), nameof(TestSavedGame_SerializationAndDeserialization_TestData.TestCases_For_Test_SavedGame_Deserialize_AndCheckErrorMessage_ForJsonException_WhenNoJsonTokens))]
-        [Category("SavedGame Deserialize Failure")]
-        public void Test_SavedGame_Deserialize_AndCheckErrorMessage_ForJsonException_WhenNoJsonTokens(string expectedErrorMessage, string textInFile)
+        [TestCaseSource(typeof(TestSavedGame_SerializationAndDeserialization_TestData), 
+            nameof(TestSavedGame_SerializationAndDeserialization_TestData.TestCases_For_Test_SavedGame_Deserialize_AndCheckErrorMessage_WhenNoJsonTokens))]
+        [Category("SavedGame Deserialize JsonException Failure")]
+        public void Test_SavedGame_Deserialize_AndCheckErrorMessage_WhenNoJsonTokens(string expectedErrorMessage, string textInFile)
         {
             Assert.Multiple(() =>
             {
@@ -199,9 +200,10 @@ namespace HideAndSeek
             });
         }
 
-        [TestCaseSource(typeof(TestSavedGame_SerializationAndDeserialization_TestData), nameof(TestSavedGame_SerializationAndDeserialization_TestData.TestCases_For_Test_SavedGame_Deserialize_AndCheckErrorMessage_ForJsonException_WhenPropertyIsMissing))]
-        [Category("SavedGame Deserialize Failure")]
-        public void Test_SavedGame_Deserialize_AndCheckErrorMessage_ForJsonException_WhenPropertyIsMissing(string expectedErrorMessage, string textInFile)
+        [TestCaseSource(typeof(TestSavedGame_SerializationAndDeserialization_TestData), 
+            nameof(TestSavedGame_SerializationAndDeserialization_TestData.TestCases_For_Test_SavedGame_Deserialize_AndCheckErrorMessage_WhenPropertyIsMissing))]
+        [Category("SavedGame Deserialize JsonException Failure")]
+        public void Test_SavedGame_Deserialize_AndCheckErrorMessage_WhenPropertyIsMissing(string expectedErrorMessage, string textInFile)
         {
             // Set House file system to mock file system to return text in file
             House.FileSystem = MockFileSystemHelper.GetMockedFileSystem_ToReadAllText("DefaultHouse.json", 
@@ -220,9 +222,10 @@ namespace HideAndSeek
             });
         }
 
-        [TestCaseSource(typeof(TestSavedGame_SerializationAndDeserialization_TestData), nameof(TestSavedGame_SerializationAndDeserialization_TestData.TestCases_For_Test_SavedGame_Deserialize_AndCheckErrorMessage_ForInvalidDataException_WhenFileDataHasInvalidValue))]
-        [Category("SavedGame Deserialize Failure")]
-        public void Test_SavedGame_Deserialize_AndCheckErrorMessage_ForInvalidDataException_WhenFileDataHasInvalidValue(string expectedErrorMessage, string textInFile)
+        [TestCaseSource(typeof(TestSavedGame_SerializationAndDeserialization_TestData), 
+            nameof(TestSavedGame_SerializationAndDeserialization_TestData.TestCases_For_Test_SavedGame_Deserialize_AndCheckErrorMessage_WhenFileDataHasInvalidValue))]
+        [Category("SavedGame Deserialize InvalidOperationException Failure")]
+        public void Test_SavedGame_Deserialize_AndCheckErrorMessage_WhenFileDataHasInvalidValue(string expectedErrorMessage, string textInFile)
         {
             // Set House file system to mock file system to return text in file
             House.FileSystem = MockFileSystemHelper.GetMockedFileSystem_ToReadAllText("DefaultHouse.json", 
@@ -231,7 +234,7 @@ namespace HideAndSeek
             Assert.Multiple(() =>
             {
                 // Assert that deserialization raises an exception
-                var exception = Assert.Throws<InvalidDataException>(() =>
+                var exception = Assert.Throws<InvalidOperationException>(() =>
                 {
                     JsonSerializer.Deserialize<SavedGame>(textInFile);
                 });
@@ -243,7 +246,7 @@ namespace HideAndSeek
 
         [Test]
         [Category("SavedGame Deserialize ArgumentException Failure")]
-        public void Test_SavedGame_Deserialize_AndCheckErrorMessage_ForInvalidDataException_WhenFileDataHasInvalidValue_ForHouseFileName()
+        public void Test_SavedGame_Deserialize_AndCheckErrorMessage_WhenFileDataHasInvalidValue_ForHouseFileName()
         {
             // Set House file system to mock file system to return text in file
             House.FileSystem = MockFileSystemHelper.GetMockedFileSystem_ToReadAllText("DefaultHouse.json",
@@ -266,13 +269,70 @@ namespace HideAndSeek
 
                 // Assert that exception message is as expected
                 Assert.That(exception.Message, Does.StartWith("Cannot perform action because file name \"a8}{{ /@uaou12 \" is invalid " +
-                                                          "(is empty or contains illegal characters, e.g. \\, /, or whitespace)"));
+                                                               "(is empty or contains illegal characters, e.g. \\, /, or whitespace)"));
             });
         }
 
-        [TestCaseSource(typeof(TestSavedGame_SerializationAndDeserialization_TestData), nameof(TestSavedGame_SerializationAndDeserialization_TestData.TestCases_For_Test_SavedGame_Deserialize_AndCheckErrorMessage_ForJsonException_WhenHouseFileFormatIsInvalid))]
-        [Category("SavedGame Deserialize House Failure")]
-        public void Test_SavedGame_Deserialize_AndCheckErrorMessage_ForJsonException_WhenHouseFileFormatIsInvalid(string exceptionMessageEnding, string houseFileText)
+        [Test]
+        [Category("SavedGame Deserialize ArgumentOutOfRangeException Failure")]
+        public void Test_SavedGame_Deserialize_AndCheckErrorMessage_WhenFileDataHasInvalidValue_ForMoveNumber()
+        {
+            // Set House file system to mock file system to return text in file
+            House.FileSystem = MockFileSystemHelper.GetMockedFileSystem_ToReadAllText("DefaultHouse.json",
+                                    TestSavedGame_SerializationAndDeserialization_TestData.DefaultHouse_Serialized);
+
+            Assert.Multiple(() =>
+            {
+                // Assert that deserialization raises an exception
+                var exception = Assert.Throws<ArgumentOutOfRangeException>(() =>
+                {
+                    JsonSerializer.Deserialize<SavedGame>(
+                        "{" +
+                            TestSavedGame_SerializationAndDeserialization_TestData.SavedGame_Serialized_HouseFileName + "," +
+                            TestSavedGame_SerializationAndDeserialization_TestData.SavedGame_Serialized_PlayerLocation_NoFoundOpponents + "," +
+                            "\"MoveNumber\":-1" + "," +
+                            TestSavedGame_SerializationAndDeserialization_TestData.SavedGame_Serialized_OpponentsAndHidingLocations + "," +
+                            TestSavedGame_SerializationAndDeserialization_TestData.SavedGame_Serialized_FoundOpponents_NoFoundOpponents +
+                        "}");
+                });
+
+                // Assert that exception message is as expected
+                Assert.That(exception.Message, Does.StartWith("MoveNumber is invalid - must be positive number"));
+            });
+        }
+
+        [Test]
+        [Category("SavedGame Deserialize ArgumentException Failure")]
+        public void Test_SavedGame_Deserialize_AndCheckErrorMessage_WhenFileDataHasInvalidValue_ForOpponents()
+        {
+            // Set House file system to mock file system to return text in file
+            House.FileSystem = MockFileSystemHelper.GetMockedFileSystem_ToReadAllText("DefaultHouse.json",
+                                    TestSavedGame_SerializationAndDeserialization_TestData.DefaultHouse_Serialized);
+
+            Assert.Multiple(() =>
+            {
+                // Assert that deserialization raises an exception
+                var exception = Assert.Throws<ArgumentException>(() =>
+                {
+                    JsonSerializer.Deserialize<SavedGame>(
+                        "{" +
+                            TestSavedGame_SerializationAndDeserialization_TestData.SavedGame_Serialized_HouseFileName + "," +
+                            TestSavedGame_SerializationAndDeserialization_TestData.SavedGame_Serialized_PlayerLocation_NoFoundOpponents + "," +
+                            TestSavedGame_SerializationAndDeserialization_TestData.SavedGame_Serialized_MoveNumber_NoFoundOpponents + "," +
+                            "\"OpponentsAndHidingLocations\":{}" + "," +
+                            TestSavedGame_SerializationAndDeserialization_TestData.SavedGame_Serialized_FoundOpponents_NoFoundOpponents +
+                        "}");
+                });
+
+                // Assert that exception message is as expected
+                Assert.That(exception.Message, Does.StartWith("invalid OpponentsAndHidingLocations - no opponents"));
+            });
+        }
+
+        [TestCaseSource(typeof(TestSavedGame_SerializationAndDeserialization_TestData), 
+            nameof(TestSavedGame_SerializationAndDeserialization_TestData.TestCases_For_Test_SavedGame_Deserialize_AndCheckErrorMessage_WhenHouseFileFormatIsInvalid))]
+        [Category("SavedGame Deserialize House JsonException Failure")]
+        public void Test_SavedGame_Deserialize_AndCheckErrorMessage_WhenHouseFileFormatIsInvalid(string exceptionMessageEnding, string houseFileText)
         {
             // Set House file system to mock file system to return text in file
             House.FileSystem = MockFileSystemHelper.GetMockedFileSystem_ToReadAllText("DefaultHouse.json", houseFileText);
@@ -290,9 +350,10 @@ namespace HideAndSeek
             });
         }
 
-        [TestCaseSource(typeof(TestSavedGame_SerializationAndDeserialization_TestData), nameof(TestSavedGame_SerializationAndDeserialization_TestData.TestCases_For_Test_SavedGame_Deserialize_AndCheckErrorMessage_ForInvalidDataException_WhenHouseFileDataInvalidValue))]
-        [Category("SavedGame Deserialize House Failure")]
-        public void Test_SavedGame_Deserialize_AndCheckErrorMessage_ForInvalidDataException_WhenHouseFileDataInvalidValue(string exceptionMessageEnding, string houseFileText)
+        [TestCaseSource(typeof(TestSavedGame_SerializationAndDeserialization_TestData), 
+            nameof(TestSavedGame_SerializationAndDeserialization_TestData.TestCases_For_Test_SavedGame_Deserialize_AndCheckErrorMessage_WhenHouseFileDataInvalidValue))]
+        [Category("SavedGame Deserialize House ArgumentException Failure")]
+        public void Test_SavedGame_Deserialize_AndCheckErrorMessage_WhenHouseFileDataInvalidValue(string exceptionDescription, string houseFileText)
         {
             // Set House file system to mock file system to return text in file
             House.FileSystem = MockFileSystemHelper.GetMockedFileSystem_ToReadAllText("DefaultHouse.json", houseFileText);
@@ -300,20 +361,21 @@ namespace HideAndSeek
             Assert.Multiple(() =>
             {
                 // Assert that deserializing a SavedGame with a reference to a House with invalid file data raises an exception
-                var exception = Assert.Throws<InvalidDataException>(() =>
+                var exception = Assert.Throws<ArgumentException>(() =>
                 {
                     JsonSerializer.Deserialize<SavedGame>(TestSavedGame_SerializationAndDeserialization_TestData.SavedGame_Serialized_NoFoundOpponents);
                 });
                 
                 // Assert that exception message is as expected
-                Assert.That(exception.Message, Is.EqualTo($"Cannot process because data in house layout file DefaultHouse is invalid - {exceptionMessageEnding}"));
+                Assert.That(exception.Message, Does.StartWith(
+                    $"Cannot process because data in house layout file DefaultHouse is invalid - {exceptionDescription}"));
             });
         }
 
         [TestCaseSource(typeof(TestSavedGame_SerializationAndDeserialization_TestData),
-            nameof(TestSavedGame_SerializationAndDeserialization_TestData.TestCases_For_Test_SavedGame_Deserialize_AndCheckErrorMessage_ForInvalidOperationException_WhenHouseFileDataInvalidValue_NonexistentLocation))]
+            nameof(TestSavedGame_SerializationAndDeserialization_TestData.TestCases_For_Test_SavedGame_Deserialize_AndCheckErrorMessage_WhenHouseFileDataInvalidValue_NonexistentLocation))]
         [Category("SavedGame Deserialize House InvalidOperationException Failure")]
-        public void Test_SavedGame_Deserialize_AndCheckErrorMessage_ForInvalidOperationException_WhenHouseFileDataInvalidValue_NonexistentLocation(string exceptionDescription, string houseFileText)
+        public void Test_SavedGame_Deserialize_AndCheckErrorMessage_WhenHouseFileDataInvalidValue_NonexistentLocation(string exceptionDescription, string houseFileText)
         {
             // Set House file system to mock file system to return text in file
             House.FileSystem = MockFileSystemHelper.GetMockedFileSystem_ToReadAllText("DefaultHouse.json", houseFileText);
@@ -332,9 +394,10 @@ namespace HideAndSeek
             });
         }
 
-        [TestCaseSource(typeof(TestSavedGame_SerializationAndDeserialization_TestData), nameof(TestSavedGame_SerializationAndDeserialization_TestData.TestCases_For_Test_SavedGame_Deserialize_AndCheckErrorMessage_ForJsonException_WhenHouseFileDataHasInvalidDirection))]
-        [Category("SavedGame Deserialize House Failure")]
-        public void Test_SavedGame_Deserialize_AndCheckErrorMessage_ForJsonException_WhenHouseFileDataHasInvalidDirection(string houseFileText)
+        [TestCaseSource(typeof(TestSavedGame_SerializationAndDeserialization_TestData), 
+            nameof(TestSavedGame_SerializationAndDeserialization_TestData.TestCases_For_Test_SavedGame_Deserialize_AndCheckErrorMessage_WhenHouseFileDataHasInvalidDirection))]
+        [Category("SavedGame Deserialize House JsonException Failure")]
+        public void Test_SavedGame_Deserialize_AndCheckErrorMessage_WhenHouseFileDataHasInvalidDirection(string houseFileText)
         {
             // Set House file system to mock file system to return text in file
             House.FileSystem = MockFileSystemHelper.GetMockedFileSystem_ToReadAllText("DefaultHouse.json", houseFileText);

--- a/HideAndSeekTestProject/TestSavedGame_SerializationAndDeserialization.cs
+++ b/HideAndSeekTestProject/TestSavedGame_SerializationAndDeserialization.cs
@@ -310,6 +310,28 @@ namespace HideAndSeek
             });
         }
 
+        [TestCaseSource(typeof(TestSavedGame_SerializationAndDeserialization_TestData),
+            nameof(TestSavedGame_SerializationAndDeserialization_TestData.TestCases_For_Test_SavedGame_Deserialize_AndCheckErrorMessage_ForInvalidOperationException_WhenHouseFileDataInvalidValue_NonexistentLocation))]
+        [Category("SavedGame Deserialize House InvalidOperationException Failure")]
+        public void Test_SavedGame_Deserialize_AndCheckErrorMessage_ForInvalidOperationException_WhenHouseFileDataInvalidValue_NonexistentLocation(string exceptionDescription, string houseFileText)
+        {
+            // Set House file system to mock file system to return text in file
+            House.FileSystem = MockFileSystemHelper.GetMockedFileSystem_ToReadAllText("DefaultHouse.json", houseFileText);
+
+            Assert.Multiple(() =>
+            {
+                // Assert that deserializing a SavedGame with a reference to a House with invalid file data raises an exception
+                var exception = Assert.Throws<InvalidOperationException>(() =>
+                {
+                    JsonSerializer.Deserialize<SavedGame>(TestSavedGame_SerializationAndDeserialization_TestData.SavedGame_Serialized_NoFoundOpponents);
+                });
+
+                // Assert that exception message is as expected
+                Assert.That(exception.Message, Does.StartWith(
+                     $"Cannot process because data in house layout file DefaultHouse is corrupt - {exceptionDescription}"));
+            });
+        }
+
         [TestCaseSource(typeof(TestSavedGame_SerializationAndDeserialization_TestData), nameof(TestSavedGame_SerializationAndDeserialization_TestData.TestCases_For_Test_SavedGame_Deserialize_AndCheckErrorMessage_ForJsonException_WhenHouseFileDataHasInvalidDirection))]
         [Category("SavedGame Deserialize House Failure")]
         public void Test_SavedGame_Deserialize_AndCheckErrorMessage_ForJsonException_WhenHouseFileDataHasInvalidDirection(string houseFileText)

--- a/HideAndSeekTestProject/TestSavedGame_SerializationAndDeserialization.cs
+++ b/HideAndSeekTestProject/TestSavedGame_SerializationAndDeserialization.cs
@@ -265,7 +265,7 @@ namespace HideAndSeek
                 });
 
                 // Assert that exception message is as expected
-                Assert.That(exception.Message, Is.EqualTo("Cannot perform action because file name \"a8}{{ /@uaou12 \" is invalid " +
+                Assert.That(exception.Message, Does.StartWith("Cannot perform action because file name \"a8}{{ /@uaou12 \" is invalid " +
                                                           "(is empty or contains illegal characters, e.g. \\, /, or whitespace)"));
             });
         }

--- a/HideAndSeekTestProject/TestSavedGame_SerializationAndDeserialization_TestData.cs
+++ b/HideAndSeekTestProject/TestSavedGame_SerializationAndDeserialization_TestData.cs
@@ -842,18 +842,6 @@ namespace HideAndSeek
                    .SetName("Test_SavedGame_Deserialize_AndCheckErrorMessage_ForInvalidDataException_WhenHouseFileDataInvalidValue - LocationsWithHidingPlaces - invalid Location HidingPlace - whitespace");
 
                 // OTHER INVALID VALUES
-                // Invalid PlayerStartingPoint - not a Location
-                yield return new TestCaseData("Cannot perform action because player starting point location \"Dungeon\" " +
-                                              "is not a location in the house",
-                        "{" +
-                           DefaultHouse_Serialized_Name + "," +
-                           DefaultHouse_Serialized_HouseFileName + "," +
-                           "\"PlayerStartingPoint\":\"Dungeon\"" + "," +
-                           DefaultHouse_Serialized_LocationsWithoutHidingPlaces + "," +
-                           DefaultHouse_Serialized_LocationsWithHidingPlaces +
-                       "}")
-                   .SetName("Test_SavedGame_Deserialize_AndCheckErrorMessage_ForInvalidDataException_WhenHouseFileDataInvalidValue - invalid PlayerStartingPoint - nonexistent");
-
                 // Invalid LocationsWithHidingPlaces - empty list
                 yield return new TestCaseData("Cannot perform action because locations with hiding places list is empty",
                         "{" +
@@ -942,10 +930,99 @@ namespace HideAndSeek
                            "]" +
                        "}")
                    .SetName("Test_SavedGame_Deserialize_AndCheckErrorMessage_ForInvalidDataException_WhenHouseFileDataInvalidValue - invalid LocationsWithHidingPlaces - no exits");
+            }
+        }
+
+        public static IEnumerable TestCases_For_Test_SavedGame_Deserialize_AndCheckErrorMessage_ForJsonException_WhenHouseFileDataHasInvalidDirection
+        {
+            get
+            {
+                // Invalid LocationsWithoutHidingPlaces - exit Direction is invalid
+                yield return new TestCaseData("{" +
+                           DefaultHouse_Serialized_Name + "," +
+                           DefaultHouse_Serialized_HouseFileName + "," +
+                           DefaultHouse_Serialized_PlayerStartingPoint + "," +
+                           "\"LocationsWithoutHidingPlaces\":" +
+                           "[" +
+                                "{" +
+                                    "\"Name\":\"Hallway\"," +
+                                    "\"ExitsForSerialization\":" +
+                                    "{" +
+                                        "\"West\":\"Entry\"," +
+                                        "\"Up\":\"Attic\"" +
+                                    "}" +
+                                "}," +
+                                "{" +
+                                    "\"Name\":\"Entry\"," +
+                                    "\"ExitsForSerialization\":" +
+                                    "{" +
+                                        "\"Insideout\":\"Hallway\"" +
+                                    "}" +
+                                "}" +
+                            "]" + "," +
+                           "\"LocationsWithHidingPlaces\":" +
+                           "[" + // Must have at least one location with hiding place
+                                "{" +
+                                    "\"HidingPlace\":\"in a trunk\"," +
+                                    "\"Name\":\"Attic\"," +
+                                    "\"ExitsForSerialization\":" +
+                                    "{" +
+                                        "\"Down\":\"Hallway\"" +
+                                    "}" +
+                                "}" +
+                           "]" +
+                       "}")
+                   .SetName("Test_SavedGame_Deserialize_AndCheckErrorMessage_ForJsonException_WhenHouseFileDataHasInvalidDirection - LocationsWithoutHidingPlaces");
+
+                // Invalid LocationsWithHidingPlaces - exit direction is invalid
+                yield return new TestCaseData("{" +
+                            DefaultHouse_Serialized_Name + "," +
+                            DefaultHouse_Serialized_HouseFileName + "," +
+                            "\"PlayerStartingPoint\":\"Master Bedroom\"" + "," +
+                            "\"LocationsWithoutHidingPlaces\":" +
+                            "[" +
+                            "]" + "," +
+                            "\"LocationsWithHidingPlaces\":" +
+                            "[" +
+                                "{" +
+                                    "\"HidingPlace\":\"under the bed\"," +
+                                    "\"Name\":\"Master Bedroom\"," +
+                                    "\"ExitsForSerialization\":" +
+                                    "{" +
+                                        "\"East\":\"Master Bath\"" +
+                                    "}" +
+                                "}," +
+                                "{" +
+                                    "\"HidingPlace\":\"in the tub\"," +
+                                    "\"Name\":\"Master Bath\"," +
+                                    "\"ExitsForSerialization\":" +
+                                    "{" +
+                                        "\"Insideout\":\"Master Bedroom\"" +
+                                    "}" +
+                                "}" +
+                            "]" +
+                        "}")
+                   .SetName("Test_SavedGame_Deserialize_AndCheckErrorMessage_ForJsonException_WhenHouseFileDataHasInvalidDirection - LocationsWithHidingPlaces");
+            }
+        }
+
+        public static IEnumerable TestCases_For_Test_SavedGame_Deserialize_AndCheckErrorMessage_ForInvalidOperationException_WhenHouseFileDataInvalidValue_NonexistentLocation
+        {
+            get
+            {
+                // Invalid PlayerStartingPoint - not a Location
+                yield return new TestCaseData("location \"Dungeon\" does not exist in House",
+                        "{" +
+                           DefaultHouse_Serialized_Name + "," +
+                           DefaultHouse_Serialized_HouseFileName + "," +
+                           "\"PlayerStartingPoint\":\"Dungeon\"" + "," +
+                           DefaultHouse_Serialized_LocationsWithoutHidingPlaces + "," +
+                           DefaultHouse_Serialized_LocationsWithHidingPlaces +
+                       "}")
+                   .SetName("Test_SavedGame_Deserialize_AndCheckErrorMessage_ForInvalidOperationException_WhenHouseFileDataInvalidValue_NonexistentLocation - invalid PlayerStartingPoint - nonexistent");
 
                 // Invalid LocationsWithoutHidingPlaces - Location has nonexistent exit
-                yield return new TestCaseData("Cannot perform action because \"Hallway\" exit location \"Dungeon\" " +
-                                              "in direction \"Down\" does not exist",
+                yield return new TestCaseData("location \"Dungeon\" does not exist in House",
                         "{" +
                            DefaultHouse_Serialized_Name + "," +
                            DefaultHouse_Serialized_HouseFileName + "," +
@@ -988,11 +1065,10 @@ namespace HideAndSeek
                            "]" + "," +
                            DefaultHouse_Serialized_LocationsWithHidingPlaces +
                        "}")
-                   .SetName("Test_SavedGame_Deserialize_AndCheckErrorMessage_ForInvalidDataException_WhenHouseFileDataInvalidValue - invalid LocationsWithoutHidingPlaces - nonexistent exit");
+                   .SetName("Test_SavedGame_Deserialize_AndCheckErrorMessage_ForInvalidOperationException_WhenHouseFileDataInvalidValue_NonexistentLocation - invalid LocationsWithoutHidingPlaces - nonexistent exit");
 
                 // Invalid LocationsWithHidingPlaces - LocationWithHidingPlace has nonexistent exit
-                yield return new TestCaseData("Cannot perform action because \"Bathroom\" exit location \"Dungeon\" " +
-                                              "in direction \"Down\" does not exist",
+                yield return new TestCaseData("location \"Dungeon\" does not exist in House",
                         "{" +
                            DefaultHouse_Serialized_Name + "," +
                            DefaultHouse_Serialized_HouseFileName + "," +
@@ -1091,11 +1167,11 @@ namespace HideAndSeek
                                 "}" +
                            "]" +
                        "}")
-                   .SetName("Test_SavedGame_Deserialize_AndCheckErrorMessage_ForInvalidDataException_WhenHouseFileDataInvalidValue - invalid LocationsWithHidingPlaces - nonexistent exit");
+                   .SetName("Test_SavedGame_Deserialize_AndCheckErrorMessage_ForInvalidOperationException_WhenHouseFileDataInvalidValue_NonexistentLocation - invalid LocationsWithHidingPlaces - nonexistent exit");
             }
         }
 
-        public static IEnumerable TestCases_For_Test_SavedGame_Deserialize_AndCheckErrorMessage_ForJsonException_WhenHouseFileDataHasInvalidDirection
+        public static IEnumerable TestCases_For_Test_SavedGame_Deserialize_AndCheckErrorMessage_WhenHouseFileDataHasInvalidDirection
         {
             get
             {
@@ -1134,7 +1210,7 @@ namespace HideAndSeek
                                 "}" +
                            "]" +
                        "}")
-                   .SetName("Test_SavedGame_Deserialize_AndCheckErrorMessage_ForJsonException_WhenHouseFileDataHasInvalidDirection - LocationsWithoutHidingPlaces");
+                   .SetName("Test_SavedGame_Deserialize_AndCheckErrorMessage_WhenHouseFileDataHasInvalidDirection - LocationsWithoutHidingPlaces");
 
                 // Invalid LocationsWithHidingPlaces - exit direction is invalid
                 yield return new TestCaseData("{" +
@@ -1164,7 +1240,7 @@ namespace HideAndSeek
                                 "}" +
                             "]" +
                         "}")
-                   .SetName("Test_SavedGame_Deserialize_AndCheckErrorMessage_ForJsonException_WhenHouseFileDataHasInvalidDirection - LocationsWithHidingPlaces");
+                   .SetName("Test_SavedGame_Deserialize_AndCheckErrorMessage_WhenHouseFileDataHasInvalidDirection - LocationsWithHidingPlaces");
             }
         }
     }

--- a/HideAndSeekTestProject/TestSavedGame_SerializationAndDeserialization_TestData.cs
+++ b/HideAndSeekTestProject/TestSavedGame_SerializationAndDeserialization_TestData.cs
@@ -567,18 +567,6 @@ namespace HideAndSeek
         {
             get
             {
-                // Invalid House file name
-                yield return new TestCaseData("Cannot perform action because file name \"a8}{{ /@uaou12 \" is invalid " +
-                                              "(is empty or contains illegal characters, e.g. \\, /, or whitespace)",
-                        "{" +
-                            "\"HouseFileName\":\"a8}{{ /@uaou12 \"" + "," +
-                            SavedGame_Serialized_PlayerLocation_NoFoundOpponents + "," +
-                            SavedGame_Serialized_MoveNumber_NoFoundOpponents + "," +
-                            SavedGame_Serialized_OpponentsAndHidingLocations + "," +
-                            SavedGame_Serialized_FoundOpponents_NoFoundOpponents +
-                        "}")
-                    .SetName("Test_SavedGame_Deserialize_AndCheckErrorMessage_ForInvalidDataException_WhenFileDataHasInvalidValue - invalid HouseFileName");
-
                 // Invalid player location
                 yield return new TestCaseData("invalid PlayerLocation",
                         "{" +

--- a/HideAndSeekTestProject/TestSavedGame_SerializationAndDeserialization_TestData.cs
+++ b/HideAndSeekTestProject/TestSavedGame_SerializationAndDeserialization_TestData.cs
@@ -487,7 +487,7 @@ namespace HideAndSeek
             }
         }
 
-        public static IEnumerable TestCases_For_Test_SavedGame_Deserialize_AndCheckErrorMessage_ForJsonException_WhenNoJsonTokens
+        public static IEnumerable TestCases_For_Test_SavedGame_Deserialize_AndCheckErrorMessage_WhenNoJsonTokens
         {
             get
             {
@@ -496,23 +496,23 @@ namespace HideAndSeek
                                               "Expected the input to start with a valid JSON token, when isFinalBlock is true. " +
                                               "Path: $ | LineNumber: 0 | BytePositionInLine: 0.",
                         "")
-                    .SetName("Test_SavedGame_Deserialize_AndCheckErrorMessage_ForJsonException_WhenNoJsonTokens - no data in file");
+                    .SetName("Test_SavedGame_Deserialize_AndCheckErrorMessage_WhenNoJsonTokens - no data in file");
 
                 // Only whitespace in file
                 yield return new TestCaseData("The input does not contain any JSON tokens. " +
                                               "Expected the input to start with a valid JSON token, when isFinalBlock is true. " +
                                               "Path: $ | LineNumber: 0 | BytePositionInLine: 2.",
                         "  ")
-                    .SetName("Test_SavedGame_Deserialize_AndCheckErrorMessage_ForJsonException_WhenNoJsonTokens - only whitespace in file");
+                    .SetName("Test_SavedGame_Deserialize_AndCheckErrorMessage_WhenNoJsonTokens - only whitespace in file");
 
                 // Just characters in file (not JSON)
                 yield return new TestCaseData("'A' is an invalid start of a value. Path: $ | LineNumber: 0 | BytePositionInLine: 0.",
                         "ABCDeaoueou[{}}({}")
-                    .SetName("Test_SavedGame_Deserialize_AndCheckErrorMessage_ForJsonException_WhenNoJsonTokens - just characters in file");
+                    .SetName("Test_SavedGame_Deserialize_AndCheckErrorMessage_WhenNoJsonTokens - just characters in file");
             }
         }
 
-        public static IEnumerable TestCases_For_Test_SavedGame_Deserialize_AndCheckErrorMessage_ForJsonException_WhenPropertyIsMissing
+        public static IEnumerable TestCases_For_Test_SavedGame_Deserialize_AndCheckErrorMessage_WhenPropertyIsMissing
         {
             get
             {
@@ -525,7 +525,7 @@ namespace HideAndSeek
                             SavedGame_Serialized_OpponentsAndHidingLocations + "," +
                             SavedGame_Serialized_FoundOpponents_NoFoundOpponents +
                         "}")
-                    .SetName("Test_SavedGame_Deserialize_AndCheckErrorMessage_ForJsonException_WhenPropertyIsMissing - missing player location");
+                    .SetName("Test_SavedGame_Deserialize_AndCheckErrorMessage_WhenPropertyIsMissing - missing player location");
 
                 // Missing move number
                 yield return new TestCaseData("JSON deserialization for type 'HideAndSeek.SavedGame' was missing required properties, " +
@@ -536,7 +536,7 @@ namespace HideAndSeek
                             SavedGame_Serialized_OpponentsAndHidingLocations + "," +
                             SavedGame_Serialized_FoundOpponents_NoFoundOpponents +
                         "}")
-                    .SetName("Test_SavedGame_Deserialize_AndCheckErrorMessage_ForJsonException_WhenPropertyIsMissing - missing move number");
+                    .SetName("Test_SavedGame_Deserialize_AndCheckErrorMessage_WhenPropertyIsMissing - missing move number");
 
                 // Missing opponents and hiding locations
                 yield return new TestCaseData("JSON deserialization for type 'HideAndSeek.SavedGame' was missing required properties, " +
@@ -547,7 +547,7 @@ namespace HideAndSeek
                             SavedGame_Serialized_MoveNumber_NoFoundOpponents + "," +
                             SavedGame_Serialized_FoundOpponents_NoFoundOpponents +
                         "}")
-                    .SetName("Test_SavedGame_Deserialize_AndCheckErrorMessage_ForJsonException_WhenPropertyIsMissing - missing opponents and hiding locations");
+                    .SetName("Test_SavedGame_Deserialize_AndCheckErrorMessage_WhenPropertyIsMissing - missing opponents and hiding locations");
 
                 // Missing found opponents
                 yield return new TestCaseData("JSON deserialization for type 'HideAndSeek.SavedGame' was missing required properties, " +
@@ -558,17 +558,17 @@ namespace HideAndSeek
                             SavedGame_Serialized_MoveNumber_NoFoundOpponents + "," +
                             SavedGame_Serialized_OpponentsAndHidingLocations +
                         "}")
-                    .SetName("Test_SavedGame_Deserialize_AndCheckErrorMessage_ForJsonException_WhenPropertyIsMissing - missing found opponents");
+                    .SetName("Test_SavedGame_Deserialize_AndCheckErrorMessage_WhenPropertyIsMissing - missing found opponents");
 
             }
         }
 
-        public static IEnumerable TestCases_For_Test_SavedGame_Deserialize_AndCheckErrorMessage_ForInvalidDataException_WhenFileDataHasInvalidValue
+        public static IEnumerable TestCases_For_Test_SavedGame_Deserialize_AndCheckErrorMessage_WhenFileDataHasInvalidValue
         {
             get
             {
                 // Invalid player location
-                yield return new TestCaseData("invalid PlayerLocation",
+                yield return new TestCaseData("invalid PlayerLocation - location \"Tree\" does not exist in House",
                         "{" +
                             SavedGame_Serialized_HouseFileName + "," +
                             "\"PlayerLocation\":\"Tree\"," +
@@ -576,32 +576,10 @@ namespace HideAndSeek
                             SavedGame_Serialized_OpponentsAndHidingLocations + "," +
                             SavedGame_Serialized_FoundOpponents_NoFoundOpponents +
                         "}")
-                    .SetName("Test_SavedGame_Deserialize_AndCheckErrorMessage_ForInvalidDataException_WhenFileDataHasInvalidValue - invalid PlayerLocation");
-
-                // Invalid (negative) move number
-                yield return new TestCaseData("invalid MoveNumber",
-                        "{" +
-                            SavedGame_Serialized_HouseFileName + "," +
-                            SavedGame_Serialized_PlayerLocation_NoFoundOpponents + "," +
-                            "\"MoveNumber\":-1" + "," +
-                            SavedGame_Serialized_OpponentsAndHidingLocations + "," +
-                            SavedGame_Serialized_FoundOpponents_NoFoundOpponents +
-                        "}")
-                    .SetName("Test_SavedGame_Deserialize_AndCheckErrorMessage_ForInvalidDataException_WhenFileDataHasInvalidValue - invalid MoveNumber");
-
-                // No opponents
-                yield return new TestCaseData("no opponents",
-                        "{" +
-                            SavedGame_Serialized_HouseFileName + "," +
-                            SavedGame_Serialized_PlayerLocation_NoFoundOpponents + "," +
-                            SavedGame_Serialized_MoveNumber_NoFoundOpponents + "," +
-                            "\"OpponentsAndHidingLocations\":{}" + "," +
-                            SavedGame_Serialized_FoundOpponents_NoFoundOpponents +
-                        "}")
-                    .SetName("Test_SavedGame_Deserialize_AndCheckErrorMessage_ForInvalidDataException_WhenFileDataHasInvalidValue - no opponents");
+                    .SetName("Test_SavedGame_Deserialize_AndCheckErrorMessage_WhenFileDataHasInvalidValue - invalid PlayerLocation");
 
                 // Invalid hiding place for Joe (not yet found) because location does not exist
-                yield return new TestCaseData("invalid hiding location for opponent",
+                yield return new TestCaseData("location with hiding place \"Tree\" does not exist in House",
                         "{" +
                             SavedGame_Serialized_HouseFileName + "," +
                             SavedGame_Serialized_PlayerLocation_NoFoundOpponents + "," +
@@ -616,10 +594,10 @@ namespace HideAndSeek
                             "}" + "," +
                             SavedGame_Serialized_FoundOpponents_NoFoundOpponents +
                         "}")
-                    .SetName("Test_SavedGame_Deserialize_AndCheckErrorMessage_ForInvalidDataException_WhenFileDataHasInvalidValue - invalid hiding place for opponent - Location does not exist");
+                    .SetName("Test_SavedGame_Deserialize_AndCheckErrorMessage_WhenFileDataHasInvalidValue - invalid hiding place for opponent - Location does not exist");
 
                 // Invalid hiding place for Joe (not yet found) because hiding location is not of type LocationWithHidingPlace
-                yield return new TestCaseData("invalid hiding location for opponent",
+                yield return new TestCaseData("location with hiding place \"Hallway\" does not exist in House",
                         "{" +
                             SavedGame_Serialized_HouseFileName + "," +
                             SavedGame_Serialized_PlayerLocation_NoFoundOpponents + "," +
@@ -634,7 +612,7 @@ namespace HideAndSeek
                             "}" + "," +
                             SavedGame_Serialized_FoundOpponents_NoFoundOpponents +
                         "}")
-                    .SetName("Test_SavedGame_Deserialize_AndCheckErrorMessage_ForInvalidDataException_WhenFileDataHasInvalidValue - invalid hiding place for opponent - not LocationWithHidingPlace");
+                    .SetName("Test_SavedGame_Deserialize_AndCheckErrorMessage_WhenFileDataHasInvalidValue - invalid hiding place for opponent - not LocationWithHidingPlace");
 
                 // Found opponent is not in all opponents list
                 yield return new TestCaseData("found opponent is not an opponent",
@@ -645,11 +623,11 @@ namespace HideAndSeek
                             SavedGame_Serialized_OpponentsAndHidingLocations + "," +
                             "\"FoundOpponents\":[\"Steve\"]" +
                         "}")
-                    .SetName("Test_SavedGame_Deserialize_AndCheckErrorMessage_ForInvalidDataException_WhenFileDataHasInvalidValue - found opponent Steve is not opponent");
+                    .SetName("Test_SavedGame_Deserialize_AndCheckErrorMessage_WhenFileDataHasInvalidValue - found opponent Steve is not opponent");
             }
         }
 
-        public static IEnumerable TestCases_For_Test_SavedGame_Deserialize_AndCheckErrorMessage_ForJsonException_WhenHouseFileFormatIsInvalid
+        public static IEnumerable TestCases_For_Test_SavedGame_Deserialize_AndCheckErrorMessage_WhenHouseFileFormatIsInvalid
         {
             get
             {
@@ -659,19 +637,19 @@ namespace HideAndSeek
                                               "Expected the input to start with a valid JSON token, when isFinalBlock is true. " +
                                               "Path: $ | LineNumber: 0 | BytePositionInLine: 0.",
                         "")
-                    .SetName("Test_SavedGame_Deserialize_AndCheckErrorMessage_ForJsonException_WhenHouseFileFormatIsInvalid - empty file");
+                    .SetName("Test_SavedGame_Deserialize_AndCheckErrorMessage_WhenHouseFileFormatIsInvalid - empty file");
 
                 // File with only whitespace
                 yield return new TestCaseData("The input does not contain any JSON tokens. " +
                                               "Expected the input to start with a valid JSON token, when isFinalBlock is true. " +
                                               "Path: $ | LineNumber: 0 | BytePositionInLine: 1.",
                         " ")
-                    .SetName("Test_SavedGame_Deserialize_AndCheckErrorMessage_ForJsonException_WhenHouseFileFormatIsInvalid - only whitespace");
+                    .SetName("Test_SavedGame_Deserialize_AndCheckErrorMessage_WhenHouseFileFormatIsInvalid - only whitespace");
 
                 // File with random letters and characters
                 yield return new TestCaseData("'A' is an invalid start of a value. Path: $ | LineNumber: 0 | BytePositionInLine: 0.",
                         "ABCDeaoueou[{}}({}")
-                    .SetName("Test_SavedGame_Deserialize_AndCheckErrorMessage_ForJsonException_WhenHouseFileFormatIsInvalid - random characters");
+                    .SetName("Test_SavedGame_Deserialize_AndCheckErrorMessage_WhenHouseFileFormatIsInvalid - random characters");
 
                 // MISSING PROPERTIES
                 // File missing Name
@@ -683,7 +661,7 @@ namespace HideAndSeek
                             DefaultHouse_Serialized_LocationsWithoutHidingPlaces + "," +
                             DefaultHouse_Serialized_LocationsWithHidingPlaces +
                         "}")
-                    .SetName("Test_SavedGame_Deserialize_AndCheckErrorMessage_ForJsonException_WhenHouseFileFormatIsInvalid - no Name");
+                    .SetName("Test_SavedGame_Deserialize_AndCheckErrorMessage_WhenHouseFileFormatIsInvalid - no Name");
 
                 // File missing HouseFileName
                 yield return new TestCaseData("JSON deserialization for type 'HideAndSeek.House' was missing required properties, " +
@@ -694,7 +672,7 @@ namespace HideAndSeek
                            DefaultHouse_Serialized_LocationsWithoutHidingPlaces + "," +
                            DefaultHouse_Serialized_LocationsWithHidingPlaces +
                        "}")
-                   .SetName("Test_SavedGame_Deserialize_AndCheckErrorMessage_ForJsonException_WhenHouseFileFormatIsInvalid - no HouseFileName");
+                   .SetName("Test_SavedGame_Deserialize_AndCheckErrorMessage_WhenHouseFileFormatIsInvalid - no HouseFileName");
 
                 // File missing PlayerStartingPoint
                 yield return new TestCaseData("JSON deserialization for type 'HideAndSeek.House' was missing required properties, " +
@@ -705,7 +683,7 @@ namespace HideAndSeek
                            DefaultHouse_Serialized_LocationsWithoutHidingPlaces + "," +
                            DefaultHouse_Serialized_LocationsWithHidingPlaces +
                        "}")
-                   .SetName("Test_SavedGame_Deserialize_AndCheckErrorMessage_ForJsonException_WhenHouseFileFormatIsInvalid - no PlayerStartingPoint");
+                   .SetName("Test_SavedGame_Deserialize_AndCheckErrorMessage_WhenHouseFileFormatIsInvalid - no PlayerStartingPoint");
 
                 // File missing LocationsWithoutHidingPlaces
                 yield return new TestCaseData("JSON deserialization for type 'HideAndSeek.House' was missing required properties, " +
@@ -716,7 +694,7 @@ namespace HideAndSeek
                            DefaultHouse_Serialized_PlayerStartingPoint + "," +
                            DefaultHouse_Serialized_LocationsWithHidingPlaces +
                        "}")
-                   .SetName("Test_SavedGame_Deserialize_AndCheckErrorMessage_ForJsonException_WhenHouseFileFormatIsInvalid - no LocationsWithoutHidingPlaces");
+                   .SetName("Test_SavedGame_Deserialize_AndCheckErrorMessage_WhenHouseFileFormatIsInvalid - no LocationsWithoutHidingPlaces");
 
                 // File missing LocationsWithHidingPlaces
                 yield return new TestCaseData("JSON deserialization for type 'HideAndSeek.House' was missing required properties, " +
@@ -727,17 +705,17 @@ namespace HideAndSeek
                            DefaultHouse_Serialized_PlayerStartingPoint + "," +
                            DefaultHouse_Serialized_LocationsWithoutHidingPlaces +
                        "}")
-                   .SetName("Test_SavedGame_Deserialize_AndCheckErrorMessage_ForJsonException_WhenHouseFileFormatIsInvalid - no LocationsWithHidingPlaces");
+                   .SetName("Test_SavedGame_Deserialize_AndCheckErrorMessage_WhenHouseFileFormatIsInvalid - no LocationsWithHidingPlaces");
             }
         }
 
-        public static IEnumerable TestCases_For_Test_SavedGame_Deserialize_AndCheckErrorMessage_ForInvalidDataException_WhenHouseFileDataInvalidValue
+        public static IEnumerable TestCases_For_Test_SavedGame_Deserialize_AndCheckErrorMessage_WhenHouseFileDataInvalidValue
         {
             get
             {
                 // INVALID VALUE OF WHITESPACE
                 // Invalid Name - whitespace
-                yield return new TestCaseData("Cannot perform action because house name \" \" is invalid " +
+                yield return new TestCaseData("house name \" \" is invalid " +
                                               "(is empty or contains only whitespace)",
                         "{" +
                            "\"Name\":\" \"" + "," +
@@ -746,10 +724,10 @@ namespace HideAndSeek
                            DefaultHouse_Serialized_LocationsWithoutHidingPlaces + "," +
                            DefaultHouse_Serialized_LocationsWithHidingPlaces +
                        "}")
-                   .SetName("Test_SavedGame_Deserialize_AndCheckErrorMessage_ForInvalidDataException_WhenHouseFileDataInvalidValue - invalid Name - whitespace");
+                   .SetName("Test_SavedGame_Deserialize_AndCheckErrorMessage_WhenHouseFileDataInvalidValue - invalid Name - whitespace");
 
                 // Invalid HouseFileName - whitespace
-                yield return new TestCaseData("Cannot perform action because house file name \" \" is invalid " +
+                yield return new TestCaseData("house file name \" \" is invalid " +
                                               "(is empty or contains illegal characters, e.g. \\, /, or whitespace)",
                         "{" +
                            DefaultHouse_Serialized_Name + "," +
@@ -758,10 +736,10 @@ namespace HideAndSeek
                            DefaultHouse_Serialized_LocationsWithoutHidingPlaces + "," +
                            DefaultHouse_Serialized_LocationsWithHidingPlaces +
                        "}")
-                   .SetName("Test_SavedGame_Deserialize_AndCheckErrorMessage_ForInvalidDataException_WhenHouseFileDataInvalidValue - invalid HouseFileName - whitespace");
+                   .SetName("Test_SavedGame_Deserialize_AndCheckErrorMessage_WhenHouseFileDataInvalidValue - invalid HouseFileName - whitespace");
 
                 // Invalid PlayerStartingPoint - whitespace
-                yield return new TestCaseData("Cannot perform action because player starting point location name \" \" is invalid " +
+                yield return new TestCaseData("player starting point location name \" \" is invalid " +
                                               "(is empty or contains only whitespace)",
                         "{" +
                            DefaultHouse_Serialized_Name + "," +
@@ -770,10 +748,10 @@ namespace HideAndSeek
                            DefaultHouse_Serialized_LocationsWithoutHidingPlaces + "," +
                            DefaultHouse_Serialized_LocationsWithHidingPlaces +
                        "}")
-                   .SetName("Test_SavedGame_Deserialize_AndCheckErrorMessage_ForInvalidDataException_WhenHouseFileDataInvalidValue - invalid PlayerStartingPoint - whitespace");
+                   .SetName("Test_SavedGame_Deserialize_AndCheckErrorMessage_WhenHouseFileDataInvalidValue - invalid PlayerStartingPoint - whitespace");
 
                 // Invalid LocationsWithoutHidingPlaces - Location name is invalid (whitespace)
-                yield return new TestCaseData("Cannot perform action because location name \" \" is invalid " +
+                yield return new TestCaseData("location name \" \" is invalid " +
                                               "(is empty or contains only whitespace)",
                         "{" +
                            DefaultHouse_Serialized_Name + "," +
@@ -795,10 +773,10 @@ namespace HideAndSeek
                            "]" + "," +
                            DefaultHouse_Serialized_LocationsWithHidingPlaces +
                        "}")
-                   .SetName("Test_SavedGame_Deserialize_AndCheckErrorMessage_ForInvalidDataException_WhenHouseFileDataInvalidValue - LocationsWithoutHidingPlaces - invalid Location Name - whitespace");
+                   .SetName("Test_SavedGame_Deserialize_AndCheckErrorMessage_WhenHouseFileDataInvalidValue - LocationsWithoutHidingPlaces - invalid Location Name - whitespace");
 
                 // Invalid LocationsWithHidingPlaces - LocationWithHidingPlace name in invalid (whitespace)
-                yield return new TestCaseData("Cannot perform action because location name \" \" is invalid " +
+                yield return new TestCaseData("location name \" \" is invalid " +
                                               "(is empty or contains only whitespace)",
                         "{" +
                            DefaultHouse_Serialized_Name + "," +
@@ -817,10 +795,10 @@ namespace HideAndSeek
                                 "}" +
                             "]" +
                        "}")
-                   .SetName("Test_SavedGame_Deserialize_AndCheckErrorMessage_ForInvalidDataException_WhenHouseFileDataInvalidValue - LocationsWithHidingPlaces - invalid Location Name - whitespace");
+                   .SetName("Test_SavedGame_Deserialize_AndCheckErrorMessage_WhenHouseFileDataInvalidValue - LocationsWithHidingPlaces - invalid Location Name - whitespace");
 
                 // Invalid LocationsWithHidingPlaces - LocationWithHidingPlace description is invalid (whitespace)
-                yield return new TestCaseData("Cannot perform action because hiding place \" \" is invalid " +
+                yield return new TestCaseData("hiding place \" \" is invalid " +
                                               "(is empty or contains only whitespace)",
                         "{" +
                            DefaultHouse_Serialized_Name + "," +
@@ -839,11 +817,11 @@ namespace HideAndSeek
                                 "}" +
                             "]" +
                        "}")
-                   .SetName("Test_SavedGame_Deserialize_AndCheckErrorMessage_ForInvalidDataException_WhenHouseFileDataInvalidValue - LocationsWithHidingPlaces - invalid Location HidingPlace - whitespace");
+                   .SetName("Test_SavedGame_Deserialize_AndCheckErrorMessage_WhenHouseFileDataInvalidValue - LocationsWithHidingPlaces - invalid Location HidingPlace - whitespace");
 
                 // OTHER INVALID VALUES
                 // Invalid LocationsWithHidingPlaces - empty list
-                yield return new TestCaseData("Cannot perform action because locations with hiding places list is empty",
+                yield return new TestCaseData("locations with hiding places list is empty",
                         "{" +
                            DefaultHouse_Serialized_Name + "," +
                            DefaultHouse_Serialized_HouseFileName + "," +
@@ -869,10 +847,10 @@ namespace HideAndSeek
                            "[" +
                            "]" +
                        "}")
-                   .SetName("Test_SavedGame_Deserialize_AndCheckErrorMessage_ForInvalidDataException_WhenHouseFileDataInvalidValue - invalid LocationsWithHidingPlaces - empty");
+                   .SetName("Test_SavedGame_Deserialize_AndCheckErrorMessage_WhenHouseFileDataInvalidValue - invalid LocationsWithHidingPlaces - empty");
 
                 // Invalid LocationsWithoutHidingPlaces - Location has no exits
-                yield return new TestCaseData("Cannot perform action because location \"Hallway\" must be assigned at least one exit",
+                yield return new TestCaseData("location \"Hallway\" must be assigned at least one exit",
                         "{" +
                            DefaultHouse_Serialized_Name + "," +
                            DefaultHouse_Serialized_HouseFileName + "," +
@@ -909,10 +887,10 @@ namespace HideAndSeek
                            "]" + "," +
                            DefaultHouse_Serialized_LocationsWithHidingPlaces +
                        "}")
-                   .SetName("Test_SavedGame_Deserialize_AndCheckErrorMessage_ForInvalidDataException_WhenHouseFileDataInvalidValue - invalid LocationsWithoutHidingPlaces - no exits");
+                   .SetName("Test_SavedGame_Deserialize_AndCheckErrorMessage_WhenHouseFileDataInvalidValue - invalid LocationsWithoutHidingPlaces - no exits");
 
                 // Invalid LocationsWithHidingPlaces - LocationWithHidingPlace has no exits
-                yield return new TestCaseData("Cannot perform action because location \"Attic\" must be assigned at least one exit",
+                yield return new TestCaseData("location \"Attic\" must be assigned at least one exit",
                         "{" +
                            DefaultHouse_Serialized_Name + "," +
                            DefaultHouse_Serialized_HouseFileName + "," +
@@ -929,89 +907,17 @@ namespace HideAndSeek
                                 "}" +
                            "]" +
                        "}")
-                   .SetName("Test_SavedGame_Deserialize_AndCheckErrorMessage_ForInvalidDataException_WhenHouseFileDataInvalidValue - invalid LocationsWithHidingPlaces - no exits");
+                   .SetName("Test_SavedGame_Deserialize_AndCheckErrorMessage_WhenHouseFileDataInvalidValue - invalid LocationsWithHidingPlaces - no exits");
+
             }
         }
 
-        public static IEnumerable TestCases_For_Test_SavedGame_Deserialize_AndCheckErrorMessage_ForJsonException_WhenHouseFileDataHasInvalidDirection
-        {
-            get
-            {
-                // Invalid LocationsWithoutHidingPlaces - exit Direction is invalid
-                yield return new TestCaseData("{" +
-                           DefaultHouse_Serialized_Name + "," +
-                           DefaultHouse_Serialized_HouseFileName + "," +
-                           DefaultHouse_Serialized_PlayerStartingPoint + "," +
-                           "\"LocationsWithoutHidingPlaces\":" +
-                           "[" +
-                                "{" +
-                                    "\"Name\":\"Hallway\"," +
-                                    "\"ExitsForSerialization\":" +
-                                    "{" +
-                                        "\"West\":\"Entry\"," +
-                                        "\"Up\":\"Attic\"" +
-                                    "}" +
-                                "}," +
-                                "{" +
-                                    "\"Name\":\"Entry\"," +
-                                    "\"ExitsForSerialization\":" +
-                                    "{" +
-                                        "\"Insideout\":\"Hallway\"" +
-                                    "}" +
-                                "}" +
-                            "]" + "," +
-                           "\"LocationsWithHidingPlaces\":" +
-                           "[" + // Must have at least one location with hiding place
-                                "{" +
-                                    "\"HidingPlace\":\"in a trunk\"," +
-                                    "\"Name\":\"Attic\"," +
-                                    "\"ExitsForSerialization\":" +
-                                    "{" +
-                                        "\"Down\":\"Hallway\"" +
-                                    "}" +
-                                "}" +
-                           "]" +
-                       "}")
-                   .SetName("Test_SavedGame_Deserialize_AndCheckErrorMessage_ForJsonException_WhenHouseFileDataHasInvalidDirection - LocationsWithoutHidingPlaces");
-
-                // Invalid LocationsWithHidingPlaces - exit direction is invalid
-                yield return new TestCaseData("{" +
-                            DefaultHouse_Serialized_Name + "," +
-                            DefaultHouse_Serialized_HouseFileName + "," +
-                            "\"PlayerStartingPoint\":\"Master Bedroom\"" + "," +
-                            "\"LocationsWithoutHidingPlaces\":" +
-                            "[" +
-                            "]" + "," +
-                            "\"LocationsWithHidingPlaces\":" +
-                            "[" +
-                                "{" +
-                                    "\"HidingPlace\":\"under the bed\"," +
-                                    "\"Name\":\"Master Bedroom\"," +
-                                    "\"ExitsForSerialization\":" +
-                                    "{" +
-                                        "\"East\":\"Master Bath\"" +
-                                    "}" +
-                                "}," +
-                                "{" +
-                                    "\"HidingPlace\":\"in the tub\"," +
-                                    "\"Name\":\"Master Bath\"," +
-                                    "\"ExitsForSerialization\":" +
-                                    "{" +
-                                        "\"Insideout\":\"Master Bedroom\"" +
-                                    "}" +
-                                "}" +
-                            "]" +
-                        "}")
-                   .SetName("Test_SavedGame_Deserialize_AndCheckErrorMessage_ForJsonException_WhenHouseFileDataHasInvalidDirection - LocationsWithHidingPlaces");
-            }
-        }
-
-        public static IEnumerable TestCases_For_Test_SavedGame_Deserialize_AndCheckErrorMessage_ForInvalidOperationException_WhenHouseFileDataInvalidValue_NonexistentLocation
+        public static IEnumerable TestCases_For_Test_SavedGame_Deserialize_AndCheckErrorMessage_WhenHouseFileDataInvalidValue_NonexistentLocation
         {
             get
             {
                 // Invalid PlayerStartingPoint - not a Location
-                yield return new TestCaseData("location \"Dungeon\" does not exist in House",
+                yield return new TestCaseData("player starting point location \"Dungeon\" does not exist in House",
                         "{" +
                            DefaultHouse_Serialized_Name + "," +
                            DefaultHouse_Serialized_HouseFileName + "," +
@@ -1019,10 +925,11 @@ namespace HideAndSeek
                            DefaultHouse_Serialized_LocationsWithoutHidingPlaces + "," +
                            DefaultHouse_Serialized_LocationsWithHidingPlaces +
                        "}")
-                   .SetName("Test_SavedGame_Deserialize_AndCheckErrorMessage_ForInvalidOperationException_WhenHouseFileDataInvalidValue_NonexistentLocation - invalid PlayerStartingPoint - nonexistent");
+                   .SetName("Test_SavedGame_Deserialize_AndCheckErrorMessage_WhenHouseFileDataInvalidValue_NonexistentLocation - invalid PlayerStartingPoint - nonexistent");
 
                 // Invalid LocationsWithoutHidingPlaces - Location has nonexistent exit
-                yield return new TestCaseData("location \"Dungeon\" does not exist in House",
+                yield return new TestCaseData("\"Hallway\" exit location \"Dungeon\" " +
+                                              "in direction \"Down\" does not exist",
                         "{" +
                            DefaultHouse_Serialized_Name + "," +
                            DefaultHouse_Serialized_HouseFileName + "," +
@@ -1065,10 +972,11 @@ namespace HideAndSeek
                            "]" + "," +
                            DefaultHouse_Serialized_LocationsWithHidingPlaces +
                        "}")
-                   .SetName("Test_SavedGame_Deserialize_AndCheckErrorMessage_ForInvalidOperationException_WhenHouseFileDataInvalidValue_NonexistentLocation - invalid LocationsWithoutHidingPlaces - nonexistent exit");
+                   .SetName("Test_SavedGame_Deserialize_AndCheckErrorMessage_WhenHouseFileDataInvalidValue_NonexistentLocation - invalid LocationsWithoutHidingPlaces - nonexistent exit");
 
                 // Invalid LocationsWithHidingPlaces - LocationWithHidingPlace has nonexistent exit
-                yield return new TestCaseData("location \"Dungeon\" does not exist in House",
+                yield return new TestCaseData("\"Bathroom\" exit location \"Dungeon\" " +
+                                              "in direction \"Down\" does not exist",
                         "{" +
                            DefaultHouse_Serialized_Name + "," +
                            DefaultHouse_Serialized_HouseFileName + "," +
@@ -1167,7 +1075,7 @@ namespace HideAndSeek
                                 "}" +
                            "]" +
                        "}")
-                   .SetName("Test_SavedGame_Deserialize_AndCheckErrorMessage_ForInvalidOperationException_WhenHouseFileDataInvalidValue_NonexistentLocation - invalid LocationsWithHidingPlaces - nonexistent exit");
+                   .SetName("Test_SavedGame_Deserialize_AndCheckErrorMessage_WhenHouseFileDataInvalidValue_NonexistentLocation - invalid LocationsWithHidingPlaces - nonexistent exit");
             }
         }
 


### PR DESCRIPTION
Edit: **House methods to get location by name throw an exception if location does not exist in House**

Refactor: **Properties and methods throw ArgumentException and InvalidOperationException instead of InvalidDataException**

-throw ArgumentException instead of InvalidDataException in setters and methods
-throw InvalidOperationException when value is invalid only because of state
-add/update exception descriptions below summaries for methods
-include param name when throw ArgumentException
-update tests

Location
-make Name and Exits properties throw ArgumentException instead
-make SetExitsDictionary throw ArgumentException instead

LocationWithHidingPlace
-make HidingPlace property throw ArgumentException instead

House
-make Name, HouseFileName, PlayerStartingPoint, LocationsWithHidingPlaces, and Locations setter throw ArgumentException instead
-make StartingPoint throw InvalidOperationException instead
-remove unnecessary catch InvalidDataException in CreateHouse
-add catch ArgumentException in CreateHouse
-make SetLocationsAndStartingPoint try to set StartingPoint, catch, and throw new exception
-make SetUpHouseAfterDeserialization throw InvalidOperationException instead

SavedGame
-make House property throw ArgumentException instead
-make HouseFileName property getter throw NullReferenceException
-make PlayerLocation property throw InvalidOperationException instead
-make MoveNumber property throw ArgumentOutOfRangeException instead
-make OpponentsAndHidingLocations property throw ArgumentException and InvalidOperationException instead
-make FoundOpponents property throw InvalidOperationException instead

GameController
-remove unnecessary catch InvalidDataException in LoadGame
-add catch ArgumentOutOfRangeException in LoadGame