### PR TITLE
Fix FileExtensions GetFullFileNameForJson tests and refactor tests

### DIFF
--- a/HideAndSeekTestProject/TestFileExtensions_TestData.cs
+++ b/HideAndSeekTestProject/TestFileExtensions_TestData.cs
@@ -92,7 +92,7 @@ namespace HideAndSeek
                 yield return new TestCaseData("",
                     (string fileName) =>
                     {
-                        fileSystem.GetFullFileNameForJson(fileName);
+                        FileExtensions.GetFullFileNameForJson(fileName);
                     })
                     .SetName("Test_FileExtensions_GetFullFileNameForJson_AndCheckErrorMessage_ForInvalidFileName - class method - empty")
                     .SetCategory("FileExtensions GetFullFileNameForJson ClassMethod ArgumentException Failure");
@@ -100,7 +100,7 @@ namespace HideAndSeek
                 yield return new TestCaseData(" ",
                     (string fileName) =>
                     {
-                        fileSystem.GetFullFileNameForJson(fileName);
+                        FileExtensions.GetFullFileNameForJson(fileName);
                     })
                     .SetName("Test_FileExtensions_GetFullFileNameForJson_AndCheckErrorMessage_ForInvalidFileName - class method - whitespace")
                     .SetCategory("FileExtensions GetFullFileNameForJson ClassMethod ArgumentException Failure");
@@ -108,7 +108,7 @@ namespace HideAndSeek
                 yield return new TestCaseData(" myFile",
                     (string fileName) =>
                     {
-                        fileSystem.GetFullFileNameForJson(fileName);
+                        FileExtensions.GetFullFileNameForJson(fileName);
                     })
                     .SetName("Test_FileExtensions_GetFullFileNameForJson_AndCheckErrorMessage_ForInvalidFileName - class method - space at beginning")
                     .SetCategory("FileExtensions GetFullFileNameForJson ClassMethod ArgumentException Failure");
@@ -116,7 +116,7 @@ namespace HideAndSeek
                 yield return new TestCaseData("my file",
                     (string fileName) =>
                     {
-                        fileSystem.GetFullFileNameForJson(fileName);
+                        FileExtensions.GetFullFileNameForJson(fileName);
                     })
                     .SetName("Test_FileExtensions_GetFullFileNameForJson_AndCheckErrorMessage_ForInvalidFileName - class method - space in middle")
                     .SetCategory("FileExtensions GetFullFileNameForJson ClassMethod ArgumentException Failure");
@@ -124,7 +124,7 @@ namespace HideAndSeek
                 yield return new TestCaseData("myFile ",
                     (string fileName) =>
                     {
-                        fileSystem.GetFullFileNameForJson(fileName);
+                        FileExtensions.GetFullFileNameForJson(fileName);
                     })
                     .SetName("Test_FileExtensions_GetFullFileNameForJson_AndCheckErrorMessage_ForInvalidFileName - class method - space at end")
                     .SetCategory("FileExtensions GetFullFileNameForJson ClassMethod ArgumentException Failure");
@@ -132,7 +132,7 @@ namespace HideAndSeek
                 yield return new TestCaseData("\\my\\File\\",
                     (string fileName) =>
                     {
-                        fileSystem.GetFullFileNameForJson(fileName);
+                        FileExtensions.GetFullFileNameForJson(fileName);
                     })
                     .SetName("Test_FileExtensions_GetFullFileNameForJson_AndCheckErrorMessage_ForInvalidFileName - class method - backslashes")
                     .SetCategory("FileExtensions GetFullFileNameForJson ClassMethod ArgumentException Failure");
@@ -140,7 +140,7 @@ namespace HideAndSeek
                 yield return new TestCaseData("/my/File/",
                     (string fileName) =>
                     {
-                        fileSystem.GetFullFileNameForJson(fileName);
+                        FileExtensions.GetFullFileNameForJson(fileName);
                     })
                     .SetName("Test_FileExtensions_GetFullFileNameForJson_AndCheckErrorMessage_ForInvalidFileName - class method - forwardslashes")
                     .SetCategory("FileExtensions GetFullFileNameForJson ClassMethod ArgumentException Failure");

--- a/HideAndSeekTestProject/TestGameController_LoadGame_TestData.cs
+++ b/HideAndSeekTestProject/TestGameController_LoadGame_TestData.cs
@@ -646,11 +646,11 @@ namespace HideAndSeek
             SavedGame savedGame = new SavedGame(GetDefaultHouse(), "DefaultHouse", playerLocation, moveNumber,
                                                 new Dictionary<string, string>()
                                                 {
-                                                                    { "Joe", "Kitchen" },
-                                                                    { "Bob", "Pantry" },
-                                                                    { "Ana", "Bathroom" },
-                                                                    { "Owen", "Kitchen" },
-                                                                    { "Jimmy", "Pantry" }
+                                                    { "Joe", "Kitchen" },
+                                                    { "Bob", "Pantry" },
+                                                    { "Ana", "Bathroom" },
+                                                    { "Owen", "Kitchen" },
+                                                    { "Jimmy", "Pantry" }
                                                 },
                                                 foundOpponents);
 

--- a/HideAndSeekTestProject/TestHouse_CreateHouse.cs
+++ b/HideAndSeekTestProject/TestHouse_CreateHouse.cs
@@ -13,13 +13,10 @@ namespace HideAndSeek
     [TestFixture]
     public class TestHouse_CreateHouse
     {
-        private House house;
-
         [SetUp]
         public void SetUp()
         {
             House.FileSystem = new FileSystem(); // Set static House file system to new file system
-            house = null;
         }
 
         [OneTimeTearDown]

--- a/HideAndSeekTestProject/TestLocation.cs
+++ b/HideAndSeekTestProject/TestLocation.cs
@@ -414,9 +414,11 @@ namespace HideAndSeek
         public void Test_Location_Set_Exits()
         {
             // Create dictionary of exits
-            Dictionary<Direction, Location> exits = new Dictionary<Direction, Location>();
-            exits.Add(Direction.Out, out_yard);
-            exits.Add(Direction.North, north_kitchen);
+            Dictionary<Direction, Location> exits = new Dictionary<Direction, Location>()
+            {
+                { Direction.Out, out_yard },
+                { Direction.North, north_kitchen }
+            };
 
             // Set exits dictionary for center location
             center.Exits = exits;
@@ -447,9 +449,11 @@ namespace HideAndSeek
         public void Test_Location_Set_ExitsForSerialization()
         {
             // Create dictionary of exits
-            Dictionary<Direction, string> exits = new Dictionary<Direction, string>();
-            exits.Add(Direction.Northeast, "Secret Library");
-            exits.Add(Direction.In, "Secret Snack Corner");
+            Dictionary<Direction, string> exits = new Dictionary<Direction, string>()
+            {
+                { Direction.Northeast, "Secret Library" },
+                { Direction.In, "Secret Snack Corner" }
+            };
 
             // Set ExitsForSerialization property
             northwest_storageRoom.ExitsForSerialization = exits;
@@ -464,9 +468,11 @@ namespace HideAndSeek
         public void Test_Location_Set_ExitsForSerialization_AndCheckErrorMessage_ForInvalidExitLocationName(string locationName)
         {
             // Create dictionary of exits
-            Dictionary<Direction, string> exits = new Dictionary<Direction, string>();
-            exits.Add(Direction.South, "Game Room");
-            exits.Add(Direction.North, locationName);
+            Dictionary<Direction, string> exits = new Dictionary<Direction, string>()
+            {
+                { Direction.South, "Game Room" },
+                { Direction.North, locationName }
+            };
 
             Assert.Multiple(() =>
             {
@@ -572,19 +578,21 @@ namespace HideAndSeek
         public void Test_Location_Deserialization()
         {
             // Set expected ExitsForSerialization property value
-            IDictionary<Direction, string> expectedExitsForSerialization = new Dictionary<Direction, string>();
-            expectedExitsForSerialization.Add(Direction.North, "kitchen");
-            expectedExitsForSerialization.Add(Direction.Northeast, "pantry");
-            expectedExitsForSerialization.Add(Direction.East, "game room");
-            expectedExitsForSerialization.Add(Direction.Southeast, "study");
-            expectedExitsForSerialization.Add(Direction.South, "office");
-            expectedExitsForSerialization.Add(Direction.Southwest, "sensory room");
-            expectedExitsForSerialization.Add(Direction.West, "bedroom");
-            expectedExitsForSerialization.Add(Direction.Northwest, "storage room");
-            expectedExitsForSerialization.Add(Direction.In, "closet");
-            expectedExitsForSerialization.Add(Direction.Out, "yard");
-            expectedExitsForSerialization.Add(Direction.Up, "attic");
-            expectedExitsForSerialization.Add(Direction.Down, "basement");
+            IDictionary<Direction, string> expectedExitsForSerialization = new Dictionary<Direction, string>()
+            {
+                { Direction.North, "kitchen" },
+                { Direction.Northeast, "pantry" },
+                { Direction.East, "game room" },
+                { Direction.Southeast, "study" },
+                { Direction.South, "office" },
+                { Direction.Southwest, "sensory room" },
+                { Direction.West, "bedroom" },
+                { Direction.Northwest, "storage room" },
+                { Direction.In, "closet" },
+                { Direction.Out, "yard" },
+                { Direction.Up, "attic" },
+                { Direction.Down, "basement" }
+            };
 
             // Text representing serialized location
             string serializedLocation = 
@@ -623,8 +631,7 @@ namespace HideAndSeek
         public void Test_Location_Deserialization_AndCheckErrorMessage_ForInvalidName(string name)
         {
             // Set expected ExitsForSerialization property value
-            IDictionary<Direction, string> expectedExitsForSerialization = new Dictionary<Direction, string>();
-            expectedExitsForSerialization.Add(Direction.North, "kitchen");
+            IDictionary<Direction, string> expectedExitsForSerialization = new Dictionary<Direction, string>() { { Direction.North, "kitchen" } };
 
             // Text representing serialized Location
             string serializedLocation = 

--- a/HideAndSeekTestProject/TestLocationWithHidingPlace.cs
+++ b/HideAndSeekTestProject/TestLocationWithHidingPlace.cs
@@ -129,19 +129,21 @@ namespace HideAndSeek
         public void Test_LocationWithHidingPlace_Deserialize()
         {
             // Initialize to expected ExitsForSerialization property value
-            IDictionary<Direction, string> expectedExitsForSerialization = new Dictionary<Direction, string>();
-            expectedExitsForSerialization.Add(Direction.North, "kitchen");
-            expectedExitsForSerialization.Add(Direction.Northeast, "pantry");
-            expectedExitsForSerialization.Add(Direction.East, "game room");
-            expectedExitsForSerialization.Add(Direction.Southeast, "study");
-            expectedExitsForSerialization.Add(Direction.South, "office");
-            expectedExitsForSerialization.Add(Direction.Southwest, "sensory room");
-            expectedExitsForSerialization.Add(Direction.West, "bedroom");
-            expectedExitsForSerialization.Add(Direction.Northwest, "storage room");
-            expectedExitsForSerialization.Add(Direction.In, "closet");
-            expectedExitsForSerialization.Add(Direction.Out, "yard");
-            expectedExitsForSerialization.Add(Direction.Up, "attic");
-            expectedExitsForSerialization.Add(Direction.Down, "basement");
+            IDictionary<Direction, string> expectedExitsForSerialization = new Dictionary<Direction, string>()
+            {
+                { Direction.North, "kitchen" },
+                { Direction.Northeast, "pantry" },
+                { Direction.East, "game room" },
+                { Direction.Southeast, "study" },
+                { Direction.South, "office" },
+                { Direction.Southwest, "sensory room" },
+                { Direction.West, "bedroom" },
+                { Direction.Northwest, "storage room" },
+                { Direction.In, "closet" },
+                { Direction.Out, "yard" },
+                { Direction.Up, "attic" },
+                { Direction.Down, "basement" }
+            };
 
             // Initialize to text representing serialized object
             string serializedLocation =
@@ -183,8 +185,7 @@ namespace HideAndSeek
         public void Test_LocationWithHidingPlace_Deserialize_AndCheckErrorMessage_ForInvalidHidingLocation(string hidingPlace)
         {
             // Initialize to expected ExitsForSerialization property value
-            IDictionary<Direction, string> expectedExitsForSerialization = new Dictionary<Direction, string>();
-            expectedExitsForSerialization.Add(Direction.North, "kitchen");
+            IDictionary<Direction, string> expectedExitsForSerialization = new Dictionary<Direction, string>() { { Direction.North, "kitchen" } };
 
             // Initialize to text representing serialized object
             string serializedLocation =

--- a/HideAndSeekTestProject/TestSavedGame_Serialize.cs
+++ b/HideAndSeekTestProject/TestSavedGame_Serialize.cs
@@ -9,14 +9,6 @@ namespace HideAndSeek
     [TestFixture]
     public class TestSavedGame_Serialize
     {
-        private SavedGame savedGame;
-
-        [SetUp]
-        public void SetUp()
-        {
-            savedGame = null;
-        }
-
         // Tests all properties' getters
         [Test]
         [Category("SavedGame Serialize Success")]


### PR DESCRIPTION
- Make FileExtensions GetFullFileNameForJson class method tests call appropriate method
- Remove unused test class variables
- Use Dictionary initializer instead of Add method
- Fix spacing